### PR TITLE
Stop the logo from moving when back and settings buttons show/hide

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -27,13 +27,21 @@ function App() {
     <Router>
       <div className="App">
         <Navbar>
-          <Visibility visiblePages={[pages.TRICKDETAILS, pages.COMBODETAILS, pages.POSTTRICK, pages.POSTCOMBO]}>
-            <BackButton/>
-          </Visibility>
-          <Logo/>
-          <Visibility visiblePages={[pages.TRICKLIST]}>
-            <Settings sortingSchemes={sortingSchemes} sortOpt={sortOpt} setSortOpt={setSortOpt}/>
-          </Visibility>
+          <div style={{display: "flex", alignItems: "center", width: "100%"}}>
+            <div style={{width: "50px", height: "40px"}}>
+              <Visibility visiblePages={[pages.TRICKDETAILS, pages.COMBODETAILS, pages.POSTTRICK, pages.POSTCOMBO]} elseContent="&nbsp;">
+                <BackButton/>
+              </Visibility>
+            </div>
+            <div style={{flexGrow: "1", textAlign: "center"}}>
+              <Logo/>
+            </div>
+            <div style={{width: "50px", height: "40px"}}>
+              <Visibility visiblePages={[pages.TRICKLIST]} elseContent="&nbsp;">
+                <Settings sortingSchemes={sortingSchemes} sortOpt={sortOpt} setSortOpt={setSortOpt}/>
+              </Visibility>
+            </div>
+          </div>
         </Navbar>
         <div className="content">
           <Switch>

--- a/src/components/containers/Visibility.js
+++ b/src/components/containers/Visibility.js
@@ -1,7 +1,7 @@
 import { useLocation } from 'react-router-dom';
 import { pages } from '../../services/enums';
 
-const Visibility = ({ visiblePages, children }) => {
+const Visibility = ({ visiblePages, children, elseContent }) => {
 
   const path = useLocation().pathname.toString().toLowerCase();
 
@@ -10,13 +10,19 @@ const Visibility = ({ visiblePages, children }) => {
   visiblePages.map(page => {
     if ((page === pages.TRICKLIST && path === "/") || (page === pages.TRICKDETAILS && path.includes("/tricks/")) || (page === pages.COMBOLIST && path === "/combos") || (page === pages.COMBODETAILS && path.includes("/combos/")) || (page === pages.POSTTRICK && path === "/posttrick") || (page === pages.POSTCOMBO && path === "/postcombo") || (page === pages.GENERATOR && path === "/generator")) {
       isVisible = true;
-    } 
+    }
   });
 
   if (isVisible === true) {
     return (
       <>
         {children}
+      </>
+    );
+  } else if (elseContent !== null) {
+    return (
+      <>
+        {elseContent}
       </>
     );
   }


### PR DESCRIPTION
The buttons are now in fixed-size containers which maintain their side even if the buttons are not shown.