### PR TITLE
Show all menu options

### DIFF
--- a/src/components/layout/Settings.js
+++ b/src/components/layout/Settings.js
@@ -1,4 +1,4 @@
-import { Menu, MenuItem, MenuButton, SubMenu, MenuRadioGroup } from '@szhsin/react-menu';
+import { Menu, MenuItem, MenuButton, SubMenu, MenuRadioGroup, MenuDivider, MenuHeader } from '@szhsin/react-menu';
 import '@szhsin/react-menu/dist/index.css';
 import '@szhsin/react-menu/dist/transitions/slide.css';
 import { BsGearFill } from 'react-icons/bs';
@@ -11,11 +11,11 @@ const Settings = ({ sortingSchemes, sortOpt, setSortOpt }) => {
 
   return (
     <Menu menuButton={<button className="btn"><BsGearFill/></button>} transition>
-      <SubMenu label="Sort Options">
-        <MenuRadioGroup value={sortOpt} onRadioChange={e => setSortOpt(e.value)}>
-          {sortingSchemes.map(scheme => <MenuItem value={scheme.id} key={"scheme" + scheme.id} >{scheme.name}</MenuItem>)}
-        </MenuRadioGroup>
-      </SubMenu>
+      <MenuHeader>Sorting</MenuHeader>
+      <MenuRadioGroup value={sortOpt} onRadioChange={e => setSortOpt(e.value)}>
+        {sortingSchemes.map(scheme => <MenuItem value={scheme.id} key={"scheme" + scheme.id} >{scheme.name}</MenuItem>)}
+      </MenuRadioGroup>
+      <MenuDivider />
       <MenuItem onClick={db.populateTricks} >Reset predefined tricks</MenuItem>
       <MenuItem onClick={db.dropUserTricks} >Delete all added tricks</MenuItem>
       <MenuItem onClick={db.dropUserAtributes} >Reset stickFrequencies</MenuItem>


### PR DESCRIPTION
We have a weird UI situation where when there's not enough space for the
menu's submenu to open on the right of the menu so it opens on the left
but the submenu entry has a direction arrow that indicates that the menu
should open on the right.

I looked at trying to fic the arrow direction but it looks like it's not
optional.

So instead of trying to fix the submenu I just moved the submenu entries
in to the top-level menu and gave them a header/divider to make it
clearer.