### PR TITLE
Make youtube video looping faster

### DIFF
--- a/src/components/tricks/TrickDetails.js
+++ b/src/components/tricks/TrickDetails.js
@@ -66,7 +66,6 @@ const TrickDetails = () => {
           end: trick.videoEndTime
         }
       }
-      
     }
     else if (trick.linkToVideo.includes("instagram")) {
       // "https://www.instagram.com/p/<videoID>/embed
@@ -82,11 +81,7 @@ const TrickDetails = () => {
   }
 
   const restartVideo = (e) => {
-    e.target.loadVideoById({
-      videoId: youtubeId,
-      startSeconds: trick.videoStartTime,
-      endSeconds: trick.videoEndTime
-    });
+    e.target.seekTo(trick.videoStartTime ?? 0);
   }
 
   const editTrick = () => navigate("/posttrick",{state: {preTrick:trick}});


### PR DESCRIPTION
Previously when the video ended we triggered a reload of the video which
was slow and caused us to refetch video data. Now we seek to the video
start time. It's not 100% smooth as this causes a pause and then re-run
but it's much faster and avoids refetching the video.