### PR TITLE
Fix incorrect ordering of generated combos

### DIFF
--- a/src/services/db.js
+++ b/src/services/db.js
@@ -235,18 +235,14 @@ export default class Database {
     })
     .then(combo => this.fillComboWithTricks(combo));
 
-  // fill a combo, which has only ids as tricks with the tricks
+  // fill a combo, which has only ids as tricks with the full tricks
+  // (containing id, name, level, etc.)
   fillComboWithTricks = (combo) => {
-    return Promise.all(
-      this.getTricksByIds(combo.tricks))
-        .then(tricksInCombo => {
-          // Maintain the general combo details whilst replacing the old trick ids with
-          // the full tricks (containing id, name, level, etc.).
-          let comboWithTricks = combo;
-          comboWithTricks.tricks = tricksInCombo;
-          return comboWithTricks;
-        }
-    );
+    return Promise.all(this.getTricksByIds(combo.tricks))
+      .then(tricksInCombo => {
+        combo.tricks = tricksInCombo;
+        return combo;
+      });
   };
 
   // get list of all combos

--- a/src/services/db.js
+++ b/src/services/db.js
@@ -237,13 +237,16 @@ export default class Database {
 
   // fill a combo, which has only ids as tricks with the tricks
   fillComboWithTricks = (combo) => {
-    return Promise.all(this.getTricksByIds(combo.tricks)).then(tricksInCombo => {
-      tricksInCombo = tricksInCombo.filter(trick => trick);
-      let comboWithTricks = combo;
-      // change the order of the tricks to the original one
-      comboWithTricks.tricks = tricksInCombo.sort((a,b) => combo.tricks.indexOf(a.id) - combo.tricks.indexOf(b.id));
-      return comboWithTricks;
-    });
+    return Promise.all(
+      this.getTricksByIds(combo.tricks))
+        .then(tricksInCombo => {
+          // Maintain the general combo details whilst replacing the old trick ids with
+          // the full tricks (containing id, name, level, etc.).
+          let comboWithTricks = combo;
+          comboWithTricks.tricks = tricksInCombo;
+          return comboWithTricks;
+        }
+    );
   };
 
   // get list of all combos


### PR DESCRIPTION
Addresses issue #183, concerning the incorrect generation of consecutive tricks in combos, which should not not have any consecutive tricks.

The problem seemed to stem from two places:
1. The `isAnyComboConditionFulfilled` function did not cover all cases quite right and was very hard to untangle. The function was therefore refactored so that there is now less nesting of if-else-statements. The logical errors were fixed in the process.
2. When loading the tricks using `services/db.js` via the `fillComboWithTricks` function, the returned tricks get sorted so that tricks that have the same id (and therefore are the same trick) are placed right after each other. The issue was fixed by removing the filtering and sorting of the result. Please verify if the filtering and sorting did not actually serve a purpose since to my eyes they didn't seem to change the data in any other way than to alter the ordering.