### PR TITLE
Fix incorrect ordering of combo tricks and dropped duplicates

### DIFF
--- a/src/components/combos/ComboDetails.js
+++ b/src/components/combos/ComboDetails.js
@@ -23,24 +23,32 @@ const ComboDetails = ({ setUserCombo, comboToShow, addTrickToCombo }) => {
   const path = useLocation().pathname.toString().toLowerCase();
   const params = useParams();
 
-  const inGenerator = path === "/generator" ? true : false;
-  const inPostCombo = path === "/postcombo" ? true : false;
+  const inGenerator = path === "/generator"
+  const inPostCombo = path === "/postcombo"
 
 
-  const queryFunc = () => {
+  /**
+   * Depending on the page that the details are shown own, the database is queried for either the combo itself or the
+   * trick details. In either case a Promise containing an array of the tricks of the combo is returned.
+   */
+  const queryDatabaseForCombos = () => {
     if (inGenerator || inPostCombo) {
-      // convert tricks back to just numbers to then query them through the hook
+      // Convert tricks back to just numbers to then query them through the hook.
       comboToShow.tricks = comboToShow.tricks.map(trick => trick.id)
       return db.fillComboWithTricks(comboToShow);
     } else {
-      // combos query with react hooks -- means it refreshes automaticly
+      // Combos query with react hooks -- means it refreshes automatically.
       return db.getCombo(params.id);
     }
   };
 
-  const combo = useLiveQuery(() => queryFunc(), [comboToShow]);
+  const combo = useLiveQuery(() => queryDatabaseForCombos(), [comboToShow]);
 
-  if (!combo) { return null; } else { console.log("ComboAfterQuery:",combo.tricks); }
+  if (combo) {
+    console.log("ComboAfterQuery:", combo.tricks);
+  } else {
+    return null;
+  }
 
   const selectFreq = (e) => {
     const newFreq = Number(e.target.value);

--- a/src/services/db.js
+++ b/src/services/db.js
@@ -152,28 +152,38 @@ export default class Database {
       });
     });
 
-  // get list of all tricks
-  //
-  // we combine all Tricks from both of the Tables, by their ids
-  // if an attribute is set by both tables, we take the attribute of the userTricks
-  getAllTricks = () => {
-    return this.db.userTricks.toArray().then((userTricks) => {
-      return this.db.predefinedTricks.toArray().then(preTricks => {
-        return this.mergeLists(userTricks, preTricks)
-            .filter(trick => !trick.deleted)
-            .sort((a,b) => a.id - b.id);
-        });
-    });
+  /**
+   * Get a list of all tricks. All Tricks from both of the tables are combined by their ids. If an entry exists in
+   * both tables, the one from the userTricks table is used.
+   */
+  getAllTricks = async () => {
+    const[userTricks, preTricks] = await Promise.all([
+      await this.db.userTricks.toArray(),
+      await this.db.predefinedTricks.toArray(),
+    ]);
+    return this.mergeLists(userTricks, preTricks)
+        .filter(trick => !trick.deleted)
+        .sort((a,b) => a.id - b.id);
   };
 
-  // get list of tricks from ids
-  getTricksByIds = (ids) => {
-    ids = ids.map(id => Number(id));
-    return this.db.userTricks.where("id").anyOf(ids).toArray().then(userTricks => {
-      return this.db.predefinedTricks.where("id").anyOf(ids).toArray().then(preTricks => {
-        return this.mergeLists(userTricks, preTricks);
-      });
-    });
+  /**
+   * Provided a list of trick ids, a list of tricks is returned which has the same number of elements and the same order
+   * as the original list.
+   */
+  getTricksByIds = async (ids) => {
+    const allTrickInfo = await this.getAllTricks()
+    const allTrickLookup = {}
+    allTrickInfo.forEach(e => allTrickLookup[e.id] = e)
+
+    const tricks = []
+    for (let i = 0; i < ids.length; i++) {
+      if (Object.keys(allTrickLookup).includes("" + ids[i])) {
+        tricks.push(allTrickLookup[ids[i]])
+      } else {
+        throw new Error(`Id '${ids[i]}' not in database.`)
+      }
+    }
+    return tricks
   };
 
 
@@ -264,13 +274,12 @@ export default class Database {
     })
     .then(combo => this.fillComboWithTricks(combo));
 
-  // fill a combo, which has only ids as tricks with the full tricks
-  // (containing id, name, level, etc.)
-  fillComboWithTricks = (combo) => {
-    return this.getTricksByIds(combo.tricks).then(tricksInCombo => {
-      combo.tricks = tricksInCombo;
-      return combo;
-    });
+  /**
+   * Fill a combo, which has only ids as tricks with the full tricks (containing id, name, level, etc.)
+   */
+  fillComboWithTricks = async (combo) => {
+    combo.tricks = await this.getTricksByIds(combo.tricks)
+    return combo;
   };
 
   // get list of all combos


### PR DESCRIPTION
Adresses #226 and by extension other not yet mentioned issues (like for example that it was not even possible to create custom combos with duplicate tricks in them).

This is the "Necessary" fix mentioned in #226. The "Optional" fix mentioned turned out to not be a valid solution.