### PR TITLE
Add "Propose new trick" link to navigation

### DIFF
--- a/src/components/layout/LeftNav.js
+++ b/src/components/layout/LeftNav.js
@@ -10,8 +10,8 @@ import LanguageSelector from "../buttons/LanguageSelector"
 
 const LeftNav = ({ sortOpt, setSortOpt, setShowAboutPage }) => {
   const path = useLocation().pathname.toString().toLowerCase();
-  const inTrickList = path === "/" ? true : false;
-  const inComboList = path === "/combos" ? true : false;
+  const inTrickList = path === "/";
+  const inComboList = path === "/combos";
   const parentPage = parentPageOf(path);
 
   return (
@@ -55,7 +55,10 @@ const LeftNav = ({ sortOpt, setSortOpt, setShowAboutPage }) => {
       </Visibility>
       <hr />
       <LanguageSelector />
-      <a href="#" onClick={() => setShowAboutPage(true)} style={{marginTop: "1em"}}>About</a>
+      <div className="row mt-1">
+          <a className="col-8" href="https://forms.gle/Kg1Kydh8tqG4f7Vv8" target="_blank">Propose new trick</a>
+          <a className="col-4" href="#" onClick={() => setShowAboutPage(true)}>About</a>
+      </div>
     </div>
   );
 }

--- a/src/components/layout/Settings.js
+++ b/src/components/layout/Settings.js
@@ -1,10 +1,9 @@
-import { Menu, MenuItem, MenuButton, SubMenu, MenuRadioGroup, MenuDivider, MenuHeader } from '@szhsin/react-menu';
+import { Menu, MenuItem, SubMenu, MenuRadioGroup, MenuDivider, MenuHeader } from '@szhsin/react-menu';
 import '@szhsin/react-menu/dist/index.css';
 import '@szhsin/react-menu/dist/transitions/slide.css';
 import { BsGearFill } from 'react-icons/bs';
 import { useLocation } from 'react-router-dom';
 import { trickSortingSchemes, comboSortingSchemes } from '../../services/sortingSchemes';
-import { useLingui } from "@lingui/react"
 import LanguageSelector from "../buttons/LanguageSelector"
 import { useNavigate } from 'react-router';
 
@@ -17,8 +16,8 @@ const Settings = ({ sortOpt, setSortOpt, setShowAboutPage, setShowResetWarning }
 
   const path = useLocation().pathname.toString().toLowerCase();
 
-  const inTrickList = path === "/" ? true : false;
-  const inComboList = path === "/combos" ? true : false;
+  const inTrickList = path === "/";
+  const inComboList = path === "/combos";
 
   const selectImportFile = (e) => {
     const fileReader = new FileReader();
@@ -59,7 +58,7 @@ const Settings = ({ sortOpt, setSortOpt, setShowAboutPage, setShowResetWarning }
       <MenuItem><LanguageSelector /></MenuItem>
 
       <MenuDivider />
-
+      <MenuItem onClick={() => self.open("https://forms.gle/Kg1Kydh8tqG4f7Vv8")} >Propose new trick</MenuItem>
       <MenuItem onClick={() => setShowAboutPage(true)} >About</MenuItem>
     </Menu>
   );


### PR DESCRIPTION
Addresses issue #230 by adding the button to the form next to the "About" button in the navigation bar. This felt like a place where it is easy to find but not too prominent.

While working on the files, I also refactored the `let y = x === z ? true : false` lines to `let y = x === z` and removed two unused dependencies.

Result on Desktop:
![Screenshot from 2023-03-05 12-57-47](https://user-images.githubusercontent.com/33333283/222959183-f80be4cb-7acb-4937-8e1a-9ae18f835b39.png)

Result on Mobile:
![Screenshot from 2023-03-05 12-59-15](https://user-images.githubusercontent.com/33333283/222959195-fe098fed-17f1-4746-9e71-0eaa7591da21.png)


