### PR TITLE
Feature show tips as list

### DIFF
--- a/src/components/tricks/PostTrick.js
+++ b/src/components/tricks/PostTrick.js
@@ -3,17 +3,13 @@ import { useNavigate, useLocation } from "react-router-dom";
 import { positions, stickFrequencies } from "../../services/enums";
 
 import Database from "../../services/db";
+import { Form, Button, InputGroup } from "react-bootstrap";
 const db = new Database();
 
 const PostTrick = () => {
 
   const location = useLocation();
-  let preTrick;
-  if(location.state){
-    preTrick = location.state.preTrick;
-  } else {
-    console.log("location no state");
-  }
+  let preTrick = location.state?.preTrick;
 
   const [alias, setAlias] = useState(() => {
     return preTrick ? preTrick.alias : "";
@@ -43,16 +39,13 @@ const PostTrick = () => {
     return preTrick ? preTrick.description : "";
   });
   const [tips, setTips] = useState(() => {
-    return preTrick ? preTrick.tips : "";
+    return preTrick ? preTrick.tips : [];
   });
   const [stickFrequency, setStickFrequency] = useState(() => {
     return preTrick ? preTrick.stickFrequency : 0;
   });
 
-  var preId;
-  if (preTrick) {
-    preId = preTrick.id;
-  }
+  let preId = preTrick?.id;
 
   const navigate = useNavigate();
 
@@ -84,7 +77,7 @@ const PostTrick = () => {
     if (trick.endPos == "" || !trick.endPos || preTrick && trick.endPos === preTrick.endPos){ delete trick.endPos }
     if (trick.difficultyLevel == "" || !trick.difficultyLevel || preTrick && trick.difficultyLevel === preTrick.difficultyLevel){ delete trick.difficultyLevel }
     if (trick.description == "" || !trick.description || preTrick && trick.description === preTrick.description){ delete trick.description }
-    if (trick.tips == "" || !trick.tips || preTrick && trick.tips === preTrick.tips){ delete trick.tips }
+    if (trick.tips == [] || !trick.tips || preTrick && trick.tips === preTrick.tips){ delete trick.tips }
     
     db.saveTrick(trick)
     .then(() => {
@@ -104,6 +97,52 @@ const PostTrick = () => {
       <option value={i} key={i} >{item}</option>
     )
   });
+
+  /**
+   * Displays a variable length, editable list of tips. This function together with the following related ones are only
+   * slightly altered versions of the ones from the following solution to the problem:
+   * https://stackoverflow.com/a/59233716
+   */
+  function tipList() {
+    return tips.map((elem, i) =>
+      <InputGroup key={i}>
+        <Form.Control
+            type="text"
+            className="form-control"
+            value={elem||''}
+            placeholder="Try this..."
+            onChange={handleTipChange.bind(this, i)}
+        />
+        <Button
+          type="button"
+          variant="outline-danger"
+          value="remove"
+          name={i.toString()}
+          onClick={removeTip.bind(i)}
+        >
+          Remove
+        </Button>
+      </InputGroup>
+    );
+  }
+
+  function handleTipChange(i, event) {
+    let tips_ = [...tips];
+    tips_[i] = event.target.value;
+    setTips(tips_);
+  }
+
+  const removeTip = event => {
+    let index = Number(event.target.name);
+    let tips_ = [...tips];
+    tips_.splice(index, 1);
+    setTips(tips_);
+  };
+
+  const addTipField = () => {
+    setTips(tips => [...tips, '']);
+  };
+
 
   return (
     <div className="post">
@@ -208,19 +247,21 @@ const PostTrick = () => {
             />
           </div>
           <div className="col-md-6">
-            <label className="">Tips:</label>
-            <input
-              className="form-control"
-              type="text"
-              value={tips}
-              onChange={(e) => setTips(e.target.value)}
-            />
-          </div>
-          <div className="col-md-6">
             <label className="">Stick Frequency:</label>
             <select className="form-select" onChange={(e) => setStickFrequency(Number(e.target.value))}>
               {freqList}
             </select>
+          </div>
+          <div className="col-md-6">
+            <label>Tips:</label>
+            {tipList()}
+            <Button
+                variant="outline-success"
+                onClick={addTipField}
+                className={tips.length !== 0 ? "mt-2" : "ms-2"}
+            >
+              Add Tip
+            </Button>
           </div>
         </div>
         

--- a/src/components/tricks/TrickDetails.js
+++ b/src/components/tricks/TrickDetails.js
@@ -115,6 +115,13 @@ const TrickDetails = () => {
     });
   }
 
+  function TipList(props) {
+    const listItems = props.tips.map(tip =>
+      <li>{tip}</li>
+    )
+    return (<ul>{listItems}</ul>)
+  }
+
   return (
     <div className="trick-details">
       {trick && (
@@ -160,7 +167,7 @@ const TrickDetails = () => {
           {trick.tips &&
             <div>
               <h3>Tips: </h3>
-              <div className="callout">{trick.tips}</div>
+              <TipList tips={trick.tips} />
             </div>
           }
 

--- a/src/components/tricks/TrickDetails.js
+++ b/src/components/tricks/TrickDetails.js
@@ -119,7 +119,7 @@ const TrickDetails = () => {
     const listItems = props.tips.map(tip =>
       <li key={tip}>{tip}</li>
     );
-    return (<ul>{listItems}</ul>);
+    return (<ul className="callout">{listItems}</ul>);
   }
 
   return (
@@ -164,7 +164,7 @@ const TrickDetails = () => {
             </div>
           }
 
-          {trick.tips &&
+          {trick.tips && trick.tips.length > 0 &&
             <div>
               <h3>Tips: </h3>
               <TipList tips={trick.tips} />

--- a/src/components/tricks/TrickDetails.js
+++ b/src/components/tricks/TrickDetails.js
@@ -117,9 +117,9 @@ const TrickDetails = () => {
 
   function TipList(props) {
     const listItems = props.tips.map(tip =>
-      <li>{tip}</li>
-    )
-    return (<ul>{listItems}</ul>)
+      <li key={tip}>{tip}</li>
+    );
+    return (<ul>{listItems}</ul>);
   }
 
   return (

--- a/src/services/db.js
+++ b/src/services/db.js
@@ -57,15 +57,15 @@ export default class Database {
     }).upgrade(async tx => {
       await tx.table("predefinedTricks").toCollection().modify(trick => {
         if (!Array.isArray(trick.tips)) {
-          trick.tips = trick.tips ? trick.tips.split(";") : []
+          trick.tips = trick.tips ? trick.tips.split(";") : [];
         }
-      })
+      });
       await tx.table("userTricks").toCollection().modify(trick => {
         if (!Array.isArray(trick.tips)) {
-          trick.tips = trick.tips ? trick.tips.split(";") : []
+          trick.tips = trick.tips ? trick.tips.split(";") : [];
         }
-      })
-    })
+      });
+    });
 
     this.db.on('ready', () => {
       // count the tricks in the database and populate it if its empty
@@ -100,7 +100,7 @@ export default class Database {
 
   // populate the database with tricks from the predefinedTricks.js
   populateTricks = async () => {
-    await this.db.predefinedTricks.clear()
+    await this.db.predefinedTricks.clear();
 
     const trickList = Papa.parse(predefinedTricks, {dynamicTyping: true}).data;
 
@@ -112,9 +112,7 @@ export default class Database {
       trick.push(0);
       // make key value pairs
       return Object.assign.apply({},
-          header.map((v, i) => {
-            return ({[v]: trick[i]})
-          })
+          header.map((v, i) => ({[v]: trick[i]}))
       );
     });
 
@@ -128,12 +126,12 @@ export default class Database {
     });
 
     tricks.map(trick => {
-      trick.tips = trick.tips ? trick.tips.split(";") : []
-    })
+      trick.tips = trick.tips ? trick.tips.split(";") : [];
+    });
 
     // adds the tricks to the database
-    await this.db.predefinedTricks.bulkPut(tricks)
-    await this.db.versions.put({"key": "predefinedTricksVersion", "version": predefinedTricksVersion})
+    await this.db.predefinedTricks.bulkPut(tricks);
+    await this.db.versions.put({"key": "predefinedTricksVersion", "version": predefinedTricksVersion});
   };
 
   // helper function to combine two lists, 


### PR DESCRIPTION
Addresses issue #45 by changing the tips from being a single string to an array of strings, each element containing one tip. If there are no tips for the trick, the `tips` field contains an empty array. The tips column was removed from indexing.
The tips are then displayed as a list in the `TrickDetails` page. The `PostTrick` page now allows adding a variable number of tips.

TrickDetails page:
![Screenshot from 2023-03-06 12-49-41](https://user-images.githubusercontent.com/33333283/223102510-385baf47-3267-416e-ad5d-358df393d22d.png)

PostTrick page:
![Screenshot from 2023-03-10 18-15-00](https://user-images.githubusercontent.com/33333283/224380333-751c91ee-cdaa-4f6d-99dc-2bba003ce6b3.png)

### Rationale
As there were a number of suggested solutions in the comments to the issue I want to offer my reasoning as to why I consider this to be the best solution.

In contrast to [weberax's comment](https://github.com/bastislack/highline-freestyle/issues/45#issuecomment-996118294) suggesting to solve the issue in the front end, I wanted to have the tips separated into individual tips in the database. This to me is much cleaner as the back end should provide clean data while the front end should be concerned with doing its frontending. Also using a semicolon separated string in the database can cause issues when a tip contains a semicolon as a character.

However I do agree with weberax's comment in that the column does not need to be indexed (and probably shouldn't be, even though, at the current state it is in fact indexed). Looking at Dexies documentation a little more, I found a middle way: The tips can be stored as an array inside the database but don't have to be indexed. So now all tips are converted to arrays but the indexing of the column is removed entirely.

@bastislack I tried using the `transform` function of papa parse, I too think that it might be quite elegant, but I ran into multiple issues and the documentation was a little lacking so I ended up not using it.