### PR TITLE
Fix/prevent invalid input

### DIFF
--- a/src/components/combos/PostCombo.js
+++ b/src/components/combos/PostCombo.js
@@ -145,7 +145,7 @@ const PostCombo = ({ userCombo, setUserCombo }) => {
               value={yearEstablished}
               placeholder={new Date().getFullYear()}
               onChange={(e) => {
-                var value = parseInt(e.target.value)
+                const value = parseInt(e.target.value)
                 if (value >= 0 && value <= new Date().getFullYear()) {
                   setYearEstablished(value)
                 } else {

--- a/src/components/combos/PostCombo.js
+++ b/src/components/combos/PostCombo.js
@@ -104,6 +104,15 @@ const PostCombo = ({ userCombo, setUserCombo }) => {
     )
   });
 
+  const handleYearChange = (event) => {
+    const year = parseInt(event.target.value);
+    if (year < 0 || year > new Date().getFullYear()) {
+      setYearEstablished(new Date().getFullYear());
+    } else {
+      setYearEstablished(year);
+    }
+  };
+
   const addTrickToCombo = () => navigate("/", { state: {addTrickToCombo: true, preCombo: preCombo }});
   const test = () => navigate("/");
 
@@ -144,21 +153,7 @@ const PostCombo = ({ userCombo, setUserCombo }) => {
               type="number"
               value={yearEstablished}
               placeholder={new Date().getFullYear()}
-              onChange={(e) => {
-                const value = parseInt(e.target.value)
-                if (value >= 0 && value <= new Date().getFullYear()) {
-                  setYearEstablished(value)
-                } else {
-                  setYearEstablished(new Date().getFullYear())
-                }
-              }}
-              onBlur={(e) => {
-                const value = parseInt(e.target.value);
-                if (value < 0 || value > new Date().getFullYear()) {
-                  setYearEstablished(new Date().getFullYear());
-                }
-              }
-            }
+              onChange={(e) => handleYearChange(e)}
             />
           </div>
           <div className="col-md-6">

--- a/src/components/combos/PostCombo.js
+++ b/src/components/combos/PostCombo.js
@@ -144,7 +144,21 @@ const PostCombo = ({ userCombo, setUserCombo }) => {
               type="number"
               value={yearEstablished}
               placeholder={new Date().getFullYear()}
-              onChange={(e) => setYearEstablished(e.target.value)}
+              onChange={(e) => {
+                var value = parseInt(e.target.value)
+                if (value >= 0 && value <= new Date().getFullYear()) {
+                  setYearEstablished(value)
+                } else {
+                  setYearEstablished(new Date().getFullYear())
+                }
+              }}
+              onBlur={(e) => {
+                const value = parseInt(e.target.value);
+                if (value < 0 || value > new Date().getFullYear()) {
+                  setYearEstablished(new Date().getFullYear());
+                }
+              }
+            }
             />
           </div>
           <div className="col-md-6">

--- a/src/components/tricks/PostTrick.js
+++ b/src/components/tricks/PostTrick.js
@@ -93,6 +93,15 @@ const PostTrick = () => {
     })
   }
 
+  const handleYearChange = (event) => {
+    const year = parseInt(event.target.value);
+    if (year < 0 || year > new Date().getFullYear()) {
+      setYearEstablished(new Date().getFullYear());
+    } else {
+      setYearEstablished(year);
+    }
+  };
+
   const freqList = stickFrequencies.map((item, i) => {
     return (
       <option value={i} key={i}>{item}</option>
@@ -148,7 +157,7 @@ const PostTrick = () => {
               type="number"
               value={yearEstablished}
               placeholder={new Date().getFullYear()}
-              onChange={(e) => setYearEstablished(e.target.value)}
+              onChange={(e) => handleYearChange(e)}
             />
           </div>
           <div className="col-md-6">

--- a/src/components/tricks/PostTrick.js
+++ b/src/components/tricks/PostTrick.js
@@ -202,7 +202,7 @@ const PostTrick = () => {
               required
               value={difficultyLevel}
               placeholder="8"
-              onChange={(e) => { setDifficultyLevel(Math.max(0, e.target.value)); }
+              onChange={(e) => {setDifficultyLevel(Math.max(0, e.target.value));}
             }
             />
           </div>

--- a/src/components/tricks/PostTrick.js
+++ b/src/components/tricks/PostTrick.js
@@ -193,7 +193,21 @@ const PostTrick = () => {
               required
               value={difficultyLevel}
               placeholder="8"
-              onChange={(e) => setDifficultyLevel(parseInt(e.target.value))}
+              onChange={(e) => {
+                var value = parseInt(e.target.value)
+                if (value >= 0) {
+                  setDifficultyLevel(value)
+                } else {
+                  setDifficultyLevel(0)
+                }
+              }}
+              onBlur={(e) => {
+                const value = parseInt(e.target.value);
+                if (value < 0) {
+                  setDifficultyLevel(0);
+                }
+              }
+            }
             />
           </div>
           <div className="col-md-6">

--- a/src/components/tricks/PostTrick.js
+++ b/src/components/tricks/PostTrick.js
@@ -194,12 +194,7 @@ const PostTrick = () => {
               value={difficultyLevel}
               placeholder="8"
               onChange={(e) => {
-                const value = parseInt(e.target.value)
-                if (value >= 0) {
-                  setDifficultyLevel(value)
-                } else {
-                  setDifficultyLevel(0)
-                }
+                setDifficultyLevel(Math.max(0, e.target.value));
               }}
               onBlur={(e) => {
                 const value = parseInt(e.target.value);

--- a/src/components/tricks/PostTrick.js
+++ b/src/components/tricks/PostTrick.js
@@ -194,7 +194,7 @@ const PostTrick = () => {
               value={difficultyLevel}
               placeholder="8"
               onChange={(e) => {
-                var value = parseInt(e.target.value)
+                const value = parseInt(e.target.value)
                 if (value >= 0) {
                   setDifficultyLevel(value)
                 } else {

--- a/src/components/tricks/PostTrick.js
+++ b/src/components/tricks/PostTrick.js
@@ -202,15 +202,7 @@ const PostTrick = () => {
               required
               value={difficultyLevel}
               placeholder="8"
-              onChange={(e) => {
-                setDifficultyLevel(Math.max(0, e.target.value));
-              }}
-              onBlur={(e) => {
-                const value = parseInt(e.target.value);
-                if (value < 0) {
-                  setDifficultyLevel(0);
-                }
-              }
+              onChange={(e) => { setDifficultyLevel(Math.max(0, e.target.value)); }
             }
             />
           </div>


### PR DESCRIPTION
Two things have been changed here:
- The input for the `difficultyLevel` in `PostTrick.js` now does not allow negative numbers
- The input for the `yearEstablished` in `PostCombo.js` now only allows numbers that represent years from 0 to the current year
  
This is just a small adjustment, but I saw it as a good opportunity to get back into the highline-freestyle app dev team.
  
I also noticed just now that I should have put this pr into the `bug` category...