### PR TITLE
Make trick and combo list button fonts consistent

### DIFF
--- a/src/components/combos/ComboDetails.js
+++ b/src/components/combos/ComboDetails.js
@@ -102,7 +102,7 @@ const ComboDetails = ({ setUserCombo, comboToShow, addTrickToCombo }) => {
       <>
       <div className={!inPostCombo ? "col-12" : "col-9"} key={"trick" + trick.id}>
         <Link className="link-to-trick " to={`/tricks/${trick.id}`} key={"trick" + trick.id} >
-          <button className="btn trick-preview skillFreq" freq={trick.stickFrequency}>
+          <button className="btn preview-item skillFreq" freq={trick.stickFrequency}>
             <h2>{trick.alias || trick.technicalName}</h2>
           </button>
         </Link>

--- a/src/components/combos/ComboList.js
+++ b/src/components/combos/ComboList.js
@@ -44,8 +44,8 @@ const ComboList = ({ scrollPosition, setScrollPosition }) => {
     return (
       <div key={combo.id} className="combo-container col-4 col-lg-3 col-xl-2">
         <Link className="link-to-combo " to={`/combos/${combo.id}`} key={"combo" + combo.id} >
-          <button className=" btn btn-outline-success combo-preview skillFreq" freq={combo.stickFrequency} onClick={updateScrollPosition}>
-            <h3>{combo.name}</h3>
+          <button className=" btn combo-preview skillFreq" freq={combo.stickFrequency} onClick={updateScrollPosition}>
+            {combo.name}
             {combo.boostSkill && (
               <>
               <IoRocketSharp />

--- a/src/components/combos/ComboList.js
+++ b/src/components/combos/ComboList.js
@@ -44,7 +44,7 @@ const ComboList = ({ scrollPosition, setScrollPosition }) => {
     return (
       <div key={combo.id} className="combo-container col-4 col-lg-3 col-xl-2">
         <Link className="link-to-combo " to={`/combos/${combo.id}`} key={"combo" + combo.id} >
-          <button className=" btn combo-preview skillFreq" freq={combo.stickFrequency} onClick={updateScrollPosition}>
+          <button className=" btn preview-item skillFreq" freq={combo.stickFrequency} onClick={updateScrollPosition}>
             {combo.name}
             {combo.boostSkill && (
               <>

--- a/src/components/tricks/TrickDetails.js
+++ b/src/components/tricks/TrickDetails.js
@@ -198,7 +198,7 @@ const TrickDetails = () => {
               if(recommendedTrick){
                 return (
                     <div key={recommendedTrick.id} className="trick-container col-12">
-                      <button className="btn trick-preview skillFreq" freq={recommendedTrick.stickFrequency} onClick={() => {navigate(`/tricks/${recommendedTrick.id}`);}}>
+                      <button className="btn preview-item skillFreq" freq={recommendedTrick.stickFrequency} onClick={() => {navigate(`/tricks/${recommendedTrick.id}`);}}>
                         {recommendedTrick.alias || recommendedTrick.technicalName}
                         {recommendedTrick.boostSkill && (
                           <>

--- a/src/components/tricks/TrickList.js
+++ b/src/components/tricks/TrickList.js
@@ -89,7 +89,7 @@ const TrickList = ({ scrollPosition, setScrollPosition, userCombo, setUserCombo 
   function getTrickDiv(trick) {
     return (
       <div key={trick.id} className="trick-container col-4 col-lg-3 col-xl-2">
-          <button className=" btn trick-preview skillFreq" freq={trick.stickFrequency} onClick={() => onClickTrick(trick)}>
+          <button className=" btn preview-item skillFreq" freq={trick.stickFrequency} onClick={() => onClickTrick(trick)}>
             {trick.alias || trick.technicalName}
             {trick.boostSkill && (
               <>

--- a/src/index.css
+++ b/src/index.css
@@ -50,16 +50,7 @@
   justify-content: left;
 }
 
-.trick-preview {
-  margin: 2px;
-  width:95%;
-  height:95%;
-  overflow-wrap: break-word;
-  background-color: transparent;
-  border:1px solid;
-}
-
-.combo-preview {
+.preview-item {
   margin: 2px;
   width:95%;
   height:95%;

--- a/src/index.css
+++ b/src/index.css
@@ -59,11 +59,6 @@
   border:1px solid;
 }
 
-.trick-preview h3 {
-  font-weight: bold;
-  font-size: small;
-}
-
 .combo-preview {
   margin: 2px;
   width:95%;
@@ -71,11 +66,6 @@
   overflow-wrap: break-word;
   background-color: transparent;
   border:1px solid;
-}
-
-.combo-preview h3 {
-  font-weight: bold;
-  font-size: small;
 }
 
 .transition {

--- a/src/index.css
+++ b/src/index.css
@@ -66,9 +66,11 @@
 
 .combo-preview {
   margin: 2px;
-  width:100%;
-  height:100%;
+  width:95%;
+  height:95%;
   overflow-wrap: break-word;
+  background-color: transparent;
+  border:1px solid;
 }
 
 .combo-preview h3 {


### PR DESCRIPTION
This fixes #254 by removing `btn-outline-success` from the class-name and making the `combo-preview` consistent with the `trick-preview` in the index.css file.

Heres the result on the combo page:

![Screenshot](https://user-images.githubusercontent.com/50378831/229233815-2130c13e-8ae2-4239-8604-6f057819f3cd.png)

On the trick page (nothing changed here):

![Screenshot](https://user-images.githubusercontent.com/50378831/229233940-2d6720ea-b288-4f72-96e6-6101fabf45fe.png)


Before:

![image](https://user-images.githubusercontent.com/50378831/229236317-f6492223-b975-4d7e-9f46-d6fbd64b6bd3.png)