### PR TITLE
Create central VideoEmbed component

### DIFF
--- a/src/components/combos/ComboDetails.js
+++ b/src/components/combos/ComboDetails.js
@@ -13,6 +13,7 @@ import DeleteWarning from '../pop-ups/DeleteWarning';
 import computeStats from '../../logic/combos/computeStats';
 
 import Database from "../../services/db";
+import VideoEmbed from "../misc/video/VideoEmbed";
 const db = new Database();
 
 const ComboDetails = ({ setUserCombo, comboToShow, addTrickToCombo }) => {
@@ -118,47 +119,6 @@ const ComboDetails = ({ setUserCombo, comboToShow, addTrickToCombo }) => {
     );
   }
 
-  let youtubeId;
-  let youtubeOpts;
-  var instagramLink
-  if (combo && combo.linkToVideo) {
-    if (combo.linkToVideo.includes("youtu")) {
-      // "https://www.youtube.com/embed/<videoID>"
-      if (combo.linkToVideo.includes("youtu.be")) {
-        youtubeId = combo.linkToVideo.split("/").pop().split("?")[0];
-      } else {
-        youtubeId = combo.linkToVideo.split("/").pop().split("?v=").pop();
-        if (youtubeId.includes("&")) {
-          youtubeId = youtubeId.split("&")[0];
-        }
-      }
-      youtubeOpts = {
-        playerVars: {
-          autoplay: 0,
-          fs: 1,
-          rel: 0,
-          start: combo.videoStartTime,
-          end: combo.videoEndTime
-        }
-      }
-    }
-    else if (combo.linkToVideo.includes("instagram")) {
-      // "https://www.instagram.com/p/<videoID>/embed
-      instagramLink = combo.linkToVideo + "embed";
-    }
-    else {
-      console.log("Could not embed this link:\n" + combo.linkToVideo);
-    }
-  }
-
-  const setupYoutubePlayer = (e) => {
-    e.target.mute();
-  }
-
-  const restartVideo = (e) => {
-    e.target.seekTo(combo.videoStartTime ?? 0);
-  }
-
   const toggleBoostSkill = () => {
     combo.boostSkill ? combo.boostSkill = false : combo.boostSkill = true;
     db.saveCombo(combo).then(res => {
@@ -232,15 +192,8 @@ const ComboDetails = ({ setUserCombo, comboToShow, addTrickToCombo }) => {
             </div>
           }
 
-          {youtubeId &&
-            <div className="callout video-callout">
-              <YouTube className="video" videoId={youtubeId} opts={youtubeOpts} onReady={setupYoutubePlayer} onEnd={restartVideo}/>
-            </div>
-          }
-          {instagramLink &&
-            <div className="callout insta-callout">
-              <iframe className="insta-video" src={instagramLink} frameBorder="0" scrolling="no" allowtransparency="true" title="video"></iframe>
-            </div>
+          {combo.linkToVideo &&
+              <VideoEmbed link={combo.linkToVideo} timeStart={combo.videoStartTime} timeEnd={combo.videoEndTime}/>
           }
 
           {combo.comments &&

--- a/src/components/combos/ComboDetails.js
+++ b/src/components/combos/ComboDetails.js
@@ -193,7 +193,9 @@ const ComboDetails = ({ setUserCombo, comboToShow, addTrickToCombo }) => {
           }
 
           {combo.linkToVideo &&
+            <div className="container-fluid mx-0 my-2 p-0" align="center">
               <VideoEmbed link={combo.linkToVideo} timeStart={combo.videoStartTime} timeEnd={combo.videoEndTime}/>
+            </div>
           }
 
           {combo.comments &&

--- a/src/components/misc/video/InstagramEmbed.jsx
+++ b/src/components/misc/video/InstagramEmbed.jsx
@@ -1,4 +1,4 @@
-export default function InstagramEmbed({link}) {
+const InstagramEmbed = ({link}) => {
   // "https://www.instagram.com/p/<videoID>/embed
   let instagramLink = link + "embed";
 
@@ -12,3 +12,5 @@ export default function InstagramEmbed({link}) {
     ></iframe>
   );
 }
+
+export default InstagramEmbed;

--- a/src/components/misc/video/InstagramEmbed.jsx
+++ b/src/components/misc/video/InstagramEmbed.jsx
@@ -1,0 +1,14 @@
+export default function InstagramEmbed({link}) {
+  // "https://www.instagram.com/p/<videoID>/embed
+  let instagramLink = link + "embed";
+
+  return (
+    <iframe
+      style={{maxWidth: "100%", paddingBottom: "1.25rem", height: "calc(100vh - 2rem)"}}
+      src={instagramLink}
+      allowtransparency="true"
+      scrolling="no"
+      title="video"
+    ></iframe>
+  );
+}

--- a/src/components/misc/video/VideoEmbed.jsx
+++ b/src/components/misc/video/VideoEmbed.jsx
@@ -1,0 +1,76 @@
+import YouTube from "react-youtube";
+
+function VideoEmbed ({link, timeStart, timeEnd}) {
+    if (!link) {
+        return (<></>)
+    }
+
+    let youtubeOpts = {
+        playerVars: {
+            autoplay: 0,
+            fs: 1,
+            rel: 0,
+            start: timeStart,
+            end: timeEnd
+        }
+    }
+
+    let youtubeId;
+    let instagramLink;
+    if (link.includes("youtu")) {
+        // "https://www.youtube.com/embed/<videoID>"
+        if (link.includes("youtu.be")) {
+            youtubeId = link.split("/").pop().split("?")[0];
+        } else {
+            youtubeId = link.split("/").pop().split("?v=").pop();
+            if (youtubeId.includes("&")) {
+                youtubeId = youtubeId.split("&")[0];
+            }
+        }
+    }
+    else if (link.includes("instagram")) {
+        // "https://www.instagram.com/p/<videoID>/embed
+        instagramLink = link + "embed";
+    }
+    else {
+        console.log("Could not embed this link:\n" + link);
+    }
+
+    const setupYoutubePlayer = (e) => {
+        e.target.mute();
+    }
+
+    const restartVideo = (e) => {
+        e.target.seekTo(timeStart ?? 0);
+    }
+
+    return(
+        <>
+            {youtubeId &&
+                <div className="callout video-callout">
+                    <YouTube
+                        className="video"
+                        videoId={youtubeId}
+                        opts={youtubeOpts}
+                        onReady={setupYoutubePlayer}
+                        onEnd={restartVideo}
+                    />
+                </div>
+            }
+            {instagramLink &&
+                <div className="callout insta-callout">
+                    <iframe
+                        className="insta-video"
+                        src={instagramLink}
+                        frameBorder="0"
+                        scrolling="no"
+                        allowtransparency="true"
+                        title="video"
+                    ></iframe>
+                </div>
+            }
+        </>
+    );
+}
+
+export default VideoEmbed;

--- a/src/components/misc/video/VideoEmbed.jsx
+++ b/src/components/misc/video/VideoEmbed.jsx
@@ -2,7 +2,7 @@ import YouTubeEmbed from "./YouTubeEmbed";
 import InstagramEmbed from "./InstagramEmbed";
 import {Alert} from "react-bootstrap";
 
-export default function VideoEmbed ({link, timeStart, timeEnd}) {
+const VideoEmbed = ({link, timeStart, timeEnd}) => {
     if (!link) {
         return null;
     }
@@ -19,3 +19,5 @@ export default function VideoEmbed ({link, timeStart, timeEnd}) {
     console.warn("Could not embed this link:\n" + link);
     return(<Alert variant="warning">Could not display video :(</Alert>);
 }
+
+export default VideoEmbed;

--- a/src/components/misc/video/VideoEmbed.jsx
+++ b/src/components/misc/video/VideoEmbed.jsx
@@ -1,76 +1,21 @@
-import YouTube from "react-youtube";
+import YouTubeEmbed from "./YouTubeEmbed";
+import InstagramEmbed from "./InstagramEmbed";
+import {Alert} from "react-bootstrap";
 
-function VideoEmbed ({link, timeStart, timeEnd}) {
+export default function VideoEmbed ({link, timeStart, timeEnd}) {
     if (!link) {
-        return (<></>)
+        return null;
     }
 
-    let youtubeOpts = {
-        playerVars: {
-            autoplay: 0,
-            fs: 1,
-            rel: 0,
-            start: timeStart,
-            end: timeEnd
-        }
-    }
-
-    let youtubeId;
-    let instagramLink;
+    // The "be" at the end of "youtu" is missing intentionally to account for shortened "youtu.be" links
     if (link.includes("youtu")) {
-        // "https://www.youtube.com/embed/<videoID>"
-        if (link.includes("youtu.be")) {
-            youtubeId = link.split("/").pop().split("?")[0];
-        } else {
-            youtubeId = link.split("/").pop().split("?v=").pop();
-            if (youtubeId.includes("&")) {
-                youtubeId = youtubeId.split("&")[0];
-            }
-        }
-    }
-    else if (link.includes("instagram")) {
-        // "https://www.instagram.com/p/<videoID>/embed
-        instagramLink = link + "embed";
-    }
-    else {
-        console.log("Could not embed this link:\n" + link);
+        return (<YouTubeEmbed link={link} timeStart={timeStart} timeEnd={timeEnd}/>);
     }
 
-    const setupYoutubePlayer = (e) => {
-        e.target.mute();
+    if (link.includes("instagram")) {
+        return (<InstagramEmbed link={link}/>);
     }
 
-    const restartVideo = (e) => {
-        e.target.seekTo(timeStart ?? 0);
-    }
-
-    return(
-        <>
-            {youtubeId &&
-                <div className="callout video-callout">
-                    <YouTube
-                        className="video"
-                        videoId={youtubeId}
-                        opts={youtubeOpts}
-                        onReady={setupYoutubePlayer}
-                        onEnd={restartVideo}
-                    />
-                </div>
-            }
-            {instagramLink &&
-                <div className="callout insta-callout">
-                    <iframe
-                        className="insta-video"
-                        src={instagramLink}
-                        frameBorder="0"
-                        scrolling="no"
-                        allowtransparency="true"
-                        title="video"
-                    ></iframe>
-                </div>
-            }
-        </>
-    );
+    console.warn("Could not embed this link:\n" + link);
+    return(<Alert variant="warning">Could not display video :(</Alert>);
 }
-
-export default VideoEmbed;

--- a/src/components/misc/video/YouTubeEmbed.jsx
+++ b/src/components/misc/video/YouTubeEmbed.jsx
@@ -1,7 +1,7 @@
 import YouTube from "react-youtube";
 import {Ratio} from "react-bootstrap";
 
-export default function YouTubeEmbed({link, timeStart, timeEnd}) {
+const YouTubeEmbed = ({link, timeStart, timeEnd}) => {
   let youtubeOpts = {
     width: "100%",
     height: "100%",
@@ -44,3 +44,5 @@ export default function YouTubeEmbed({link, timeStart, timeEnd}) {
     </Ratio>
   );
 }
+
+export default YouTubeEmbed;

--- a/src/components/misc/video/YouTubeEmbed.jsx
+++ b/src/components/misc/video/YouTubeEmbed.jsx
@@ -1,0 +1,46 @@
+import YouTube from "react-youtube";
+import {Ratio} from "react-bootstrap";
+
+export default function YouTubeEmbed({link, timeStart, timeEnd}) {
+  let youtubeOpts = {
+    width: "100%",
+    height: "100%",
+    playerVars: {
+      autoplay: 0,
+      fs: 1,
+      rel: 0,
+      start: timeStart,
+      end: timeEnd
+    }
+  };
+
+  // "https://www.youtube.com/embed/<videoID>"
+  let youtubeId;
+  if (link.includes("youtu.be")) {
+    youtubeId = link.split("/").pop().split("?")[0];
+  } else {
+    youtubeId = link.split("/").pop().split("?v=").pop();
+    if (youtubeId.includes("&")) {
+      youtubeId = youtubeId.split("&")[0];
+    }
+  }
+
+  const setupYoutubePlayer = (e) => {
+    e.target.mute();
+  }
+
+  const restartVideo = (e) => {
+    e.target.seekTo(timeStart ?? 0);
+  }
+
+  return (
+    <Ratio aspectRatio="16x9">
+      <YouTube
+        videoId={youtubeId}
+        opts={youtubeOpts}
+        onReady={setupYoutubePlayer}
+        onEnd={restartVideo}
+      />
+    </Ratio>
+  );
+}

--- a/src/components/tricks/TrickDetails.js
+++ b/src/components/tricks/TrickDetails.js
@@ -140,7 +140,9 @@ const TrickDetails = () => {
           }
 
           {trick.linkToVideo &&
-            <VideoEmbed link={trick.linkToVideo} timeStart={trick.videoStartTime} timeEnd={trick.videoEndTime}/>
+            <div className="container-fluid mx-0 my-2 p-0" align="center">
+              <VideoEmbed link={trick.linkToVideo} timeStart={trick.videoStartTime} timeEnd={trick.videoEndTime}/>
+            </div>
           }
 
 

--- a/src/components/tricks/TrickDetails.js
+++ b/src/components/tricks/TrickDetails.js
@@ -5,12 +5,12 @@ import { useNavigate } from "react-router-dom";
 import EditButton from '../buttons/EditButton';
 import DeleteButton from '../buttons/DeleteButton';
 import FreqList from '../misc/FreqList';
-import YouTube from 'react-youtube';
 import { Trans } from '@lingui/macro'
 import DeleteWarning from '../pop-ups/DeleteWarning';
 import { IoRocketSharp } from 'react-icons/io5';
 
 import Database from "../../services/db";
+import VideoEmbed from "../misc/video/VideoEmbed";
 const db = new Database();
 
 const TrickDetails = () => {
@@ -51,47 +51,6 @@ const TrickDetails = () => {
     }).catch(e => {
       console.log(e);
     });
-  }
-
-  let youtubeId;
-  let youtubeOpts;
-  var instagramLink
-  if (trick && trick.linkToVideo) {
-    if (trick.linkToVideo.includes("youtu")) {
-      // "https://www.youtube.com/embed/<videoID>"
-      if (trick.linkToVideo.includes("youtu.be")) {
-        youtubeId = trick.linkToVideo.split("/").pop().split("?")[0];
-      } else {
-        youtubeId = trick.linkToVideo.split("/").pop().split("?v=").pop();
-        if (youtubeId.includes("&")) {
-          youtubeId = youtubeId.split("&")[0];
-        }
-      }
-      youtubeOpts = {
-        playerVars: {
-          autoplay: 0,
-          fs: 1,
-          rel: 0,
-          start: trick.videoStartTime,
-          end: trick.videoEndTime
-        }
-      }
-    }
-    else if (trick.linkToVideo.includes("instagram")) {
-      // "https://www.instagram.com/p/<videoID>/embed
-      instagramLink = trick.linkToVideo + "embed";
-    }
-    else {
-      console.log("Could not embed this link:\n" + trick.linkToVideo);
-    }
-  }
-
-  const setupYoutubePlayer = (e) => {
-    e.target.mute();
-  }
-
-  const restartVideo = (e) => {
-    e.target.seekTo(trick.videoStartTime ?? 0);
   }
 
   const editTrick = () => navigate("/posttrick",{state: {preTrick:trick}});
@@ -180,16 +139,10 @@ const TrickDetails = () => {
             </div>
           }
 
-          {youtubeId &&
-            <div className="callout video-callout">
-              <YouTube className="video" videoId={youtubeId} opts={youtubeOpts} onReady={setupYoutubePlayer} onEnd={restartVideo}/>
-            </div>
+          {trick.linkToVideo &&
+            <VideoEmbed link={trick.linkToVideo} timeStart={trick.videoStartTime} timeEnd={trick.videoEndTime}/>
           }
-          {instagramLink &&
-            <div className="callout insta-callout">
-              <iframe className="insta-video" src={instagramLink} frameBorder="0" scrolling="no" allowtransparency="true" title="video"></iframe>
-            </div>
-          }
+
 
           {trick.recommendedPrerequisites.length !== 0 &&
             <div className="row">

--- a/src/index.css
+++ b/src/index.css
@@ -183,33 +183,6 @@
   border-radius: .25rem;
 }
 
-.video-callout {
-  position: relative;
-  width: 100%;
-  height: 0;
-  padding-bottom: 56.25%;
-}
-
-.insta-callout {
-  position: relative;
-  max-width: 100%;
-  height: calc(100vh - 1rem);
-}
-
-.video {
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-}
-
-.insta-video {
-  max-width: 100%;
-  padding-bottom: 1.25rem;
-  height: calc(100vh - 2rem);
-}
-
 .form-row div {
   margin-top: 1em;
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -53,7 +53,7 @@ module.exports = {
   module: {
     rules: [
       {
-        test: /\.js$/,
+        test: /\.(js|jsx)$/,
         use: 'babel-loader'
       },
       {
@@ -98,6 +98,9 @@ module.exports = {
         ]
       }
     ]
+  },
+  resolve: {
+    extensions: ['.js', '.jsx']
   },
   plugins: webpackPlugins
 };


### PR DESCRIPTION
Addresses #250, creating a centralized component for embedded videos to avoid duplicate code.

Note: There is a change to the webpack config. This change is only a small one for webpack to also recognize ".jsx" files.

For the future it might be easier to use a module like the [react-social-media-embed](https://www.npmjs.com/package/react-social-media-embed) one to embed videos.
For now the refactor already improves the situation enough though.