### PR TITLE
Fix SearchBar.js key error

### DIFF
--- a/src/components/misc/SearchBar.js
+++ b/src/components/misc/SearchBar.js
@@ -12,13 +12,13 @@ function SearchBar({ sortingSchema, dropdownHeader, searchPattern, onFilter, onS
       <DropdownButton title="Sort">
         <Dropdown.Header>{dropdownHeader}</Dropdown.Header>
         {sortingSchema.map(scheme => 
-          <Dropdown.Item onClick={() => onSort(scheme.id)}>
+          <Dropdown.Item key={scheme.name} onClick={() => onSort(scheme.id)}>
             {scheme.name}
           </Dropdown.Item>
         )}
       </DropdownButton>
     </InputGroup>
   );
-};
+}
 
 export default SearchBar;


### PR DESCRIPTION
Since the refactor / redesign of the SearchBar component, the following error got raised in the console when opening the Trick List:
```
Warning: Each child in a list should have a unique "key" prop.

Check the render method of `SearchBar`.
[...]
```

The issue was simply that the Dropdown items of the sorting options did not have any keys assigned to them. The issue was fixed by adding keys (the scheme names) to them.
