### PR TITLE
Remove German language from internationalization

### DIFF
--- a/src/components/Navbar.vue
+++ b/src/components/Navbar.vue
@@ -30,7 +30,7 @@ const navClassList = computed( () => [
 
 
 interface LocaleInfo {
-  locale: "en" | "fr" | "es" | "de",
+  locale: "en" | "fr" | "es",
   icon: string
 }
 
@@ -47,10 +47,6 @@ const LocaleInfos: LocaleInfo[] = [
     locale: "es",
     icon: "flag:es-4x3"
   },
-  {
-    locale: "de",
-    icon: "flag:de-4x3"
-  }
 ] 
 
 const {locale} = useI18n()

--- a/src/i18n/index.de.json
+++ b/src/i18n/index.de.json
@@ -1,3 +1,0 @@
-{
-  "greeting": "Hallo Welt!"
-}

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -1,8 +1,7 @@
-import de from "./index.de.json"
 import en from "./index.en.json"
 import fr from "./index.fr.json"
 import es from "./index.es.json"
 
 export default ({
-  de, en, fr, es
+  en, fr, es
 })

--- a/src/i18n/notFound.de.json
+++ b/src/i18n/notFound.de.json
@@ -1,5 +1,0 @@
-{
-  "heading": "Nicht gefunden",
-  "body": "Die aufgerufene Seite existiert nicht.",
-  "backToIndex": "Zurück zur Startseite gehen"
-}

--- a/src/i18n/notFound.ts
+++ b/src/i18n/notFound.ts
@@ -1,6 +1,5 @@
-import de from "./notFound.de.json"
 import en from "./notFound.en.json"
 
 export default {
-  en, de
+  en
 }

--- a/src/util/locale.ts
+++ b/src/util/locale.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 
 export const LocalesZod = z.enum([
-  "en", "fr", "es", "de",
+  "en", "fr", "es",
 ])
 
 /**


### PR DESCRIPTION
It is what the title says. We decided not to implement German internationalization in the foreseeable future so I removed it entirely for now (it would not be a lot of work to add it back if needed).