### PR TITLE
Rewrite fixup GitHub linting action

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,11 +3,9 @@
 name: Linting
 
 on:
-  pull_request:
+  push:
     branches:
-      - main
-      - develop
-      - rewrite
+      - "**"
 
 jobs:
   lint:
@@ -22,7 +20,7 @@ jobs:
           cache: 'npm'
       - name: Install Dependencies from Lock-File
         run: npm ci
-      - name: Run lint-staged
-        # lint-staged gets it's own config for the CI which will not write changes
-        # e.g. using prettier --check instead of prettier --write
-        run: npx lint-staged --config .lintstagedrc-ci --diff="origin/${GITHUB_BASE_REF}...origin/${GITHUB_HEAD_REF}"
+      - name: Run Eslint
+        run: npm run lint:eslint
+      - name: Run Prettier
+        run: npm run lint:prettier

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+npm run lint:staged

--- a/.lintstagedrc-ci
+++ b/.lintstagedrc-ci
@@ -1,4 +1,0 @@
-{
-  "src/**/*.{ts,vue}": "eslint",
-  "src/**/*": "prettier --ignore-unknown --check"
-}

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "eslint": "^8.54.0",
         "eslint-plugin-vue": "^9.18.1",
         "globby": "^13.2.2",
-        "husky": "^8.0.3",
+        "husky": "^8.0.0",
         "lint-staged": "^15.1.0",
         "postcss": "^8.4.29",
         "prettier": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "eslint": "^8.54.0",
     "eslint-plugin-vue": "^9.18.1",
     "globby": "^13.2.2",
-    "husky": "^8.0.3",
+    "husky": "^8.0.0",
     "lint-staged": "^15.1.0",
     "postcss": "^8.4.29",
     "prettier": "3.1.0",


### PR DESCRIPTION
Small fix for the Github Action.

It will now run on all commits instead of just PRs and will run agains the entire project as there is otherwise issues with diffing, especially when the HEAD is on a fork.

Also fixed there not being a husky precommit hook :laughing: 