### PR TITLE
Add theming colors

### DIFF
--- a/src/routes/ThemeTest.vue
+++ b/src/routes/ThemeTest.vue
@@ -1,0 +1,80 @@
+<template>
+  <div class="bg-background text-foreground">
+    <!--
+    <div class="w-fill flex flex-row justify-center space-x-2 my-2 mx-2">
+      <div class="w-24 py-3 rounded-md text-center bg-blue-50">50</div>
+      <div class="w-24 py-3 rounded-md text-center bg-blue-100">100</div>
+      <div class="w-24 py-3 rounded-md text-center bg-blue-300">300</div>
+      <div class="w-24 py-3 rounded-md text-center bg-blue-500">blue</div>
+      <div class="w-24 py-3 rounded-md text-center bg-blue-700">700</div>
+      <div class="w-24 py-3 rounded-md text-center bg-blue-900">900</div>
+      <div class="w-24 py-3 rounded-md text-center bg-blue-950">950</div>
+    </div>
+    -->
+    <div class="w-fill flex flex-row justify-center space-x-2 my-2 mx-2">
+      <div class="w-24 py-3 rounded-md text-center text-primary-foreground bg-primary-50">50</div>
+      <div class="w-24 py-3 rounded-md text-center text-primary-foreground bg-primary-100">100</div>
+      <div class="w-24 py-3 rounded-md text-center text-primary-foreground bg-primary-300">300</div>
+      <div class="w-24 py-3 rounded-md text-center text-primary-foreground bg-primary">primary</div>
+      <div class="w-24 py-3 rounded-md text-center text-primary-foreground bg-primary-700">700</div>
+      <div class="w-24 py-3 rounded-md text-center text-primary-foreground bg-primary-900">900</div>
+      <div class="w-24 py-3 rounded-md text-center text-primary-foreground bg-primary-950">950</div>
+    </div>
+    <div class="w-fill flex flex-row justify-center space-x-2 my-2 mx-2">
+      <div class="w-24 py-3 rounded-md text-center text-secondary-foreground bg-secondary">
+        secondary
+      </div>
+    </div>
+    <div class="w-fill flex flex-row justify-center space-x-2 my-2 mx-2">
+      <div class="w-24 py-3 rounded-md text-center text-accent-foreground bg-accent">accent</div>
+    </div>
+    <div class="w-fill flex flex-row justify-center space-x-2 my-2 mx-2">
+      <div class="w-24 py-3 rounded-md text-center text-muted-foreground bg-muted">muted</div>
+    </div>
+    <div class="w-fill flex flex-row justify-center space-x-2 mt-2 mb-5 mx-2">
+      <div class="w-24 py-3 rounded-md text-center text-destructive-foreground bg-destructive-50">
+        50
+      </div>
+      <div class="w-24 py-3 rounded-md text-center text-destructive-foreground bg-destructive-100">
+        100
+      </div>
+      <div class="w-24 py-3 rounded-md text-center text-destructive-foreground bg-destructive-300">
+        300
+      </div>
+      <div class="w-24 py-3 rounded-md text-center text-destructive-foreground bg-destructive">
+        destruct.
+      </div>
+      <div class="w-24 py-3 rounded-md text-center text-destructive-foreground bg-destructive-700">
+        700
+      </div>
+      <div class="w-24 py-3 rounded-md text-center text-destructive-foreground bg-destructive-900">
+        900
+      </div>
+      <div class="w-24 py-3 rounded-md text-center text-destructive-foreground bg-destructive-950">
+        950
+      </div>
+    </div>
+
+    <div class="w-fill flex flex-row justify-center space-x-2 my-2 mx-2">
+      <div class="w-24 py-3 rounded-md text-center bg-skill1">skill1</div>
+    </div>
+    <div class="w-fill flex flex-row justify-center space-x-2 my-2 mx-2">
+      <div class="w-24 py-3 rounded-md text-center bg-skill2">skill2</div>
+    </div>
+    <div class="w-fill flex flex-row justify-center space-x-2 my-2 mx-2">
+      <div class="w-24 py-3 rounded-md text-center bg-skill3">skill3</div>
+    </div>
+    <div class="w-fill flex flex-row justify-center space-x-2 my-2 mx-2">
+      <div class="w-24 py-3 rounded-md text-center bg-skill4">skill4</div>
+    </div>
+    <div class="w-fill flex flex-row justify-center space-x-2 my-2 mx-2">
+      <div class="w-24 py-3 rounded-md text-center bg-skill5">skill5</div>
+    </div>
+    <div class="w-fill flex flex-row justify-center space-x-2 my-2 mx-2">
+      <div class="w-24 py-3 rounded-md text-center bg-skill6">skill6</div>
+    </div>
+    <div class="w-fill flex flex-row justify-center space-x-2 my-2 mx-2">
+      <div class="w-24 py-3 rounded-md text-center bg-skill7">skill7</div>
+    </div>
+  </div>
+</template>

--- a/src/routes/router.ts
+++ b/src/routes/router.ts
@@ -12,6 +12,12 @@ export default createRouter({
       component: () => import('./DbTest.vue'),
     },
     {
+      // Used for developmental purposes to determine / tune theme.
+      // Can be removed if theme is ever firmly determined.
+      path: '/theme',
+      component: () => import('./ThemeTest.vue'),
+    },
+    {
       path: '/:catchAll(.*)',
       name: 'NotFound',
       component: () => import('./NotFoundRoute.vue'),

--- a/src/tailwind.css
+++ b/src/tailwind.css
@@ -36,37 +36,6 @@
 
     --radius: 0.5rem;
   }
-
-  .dark {
-    --background: 222.2 84% 4.9%;
-    --foreground: 210 40% 98%;
-
-    --muted: 217.2 32.6% 17.5%;
-    --muted-foreground: 215 20.2% 65.1%;
-
-    --popover: 222.2 84% 4.9%;
-    --popover-foreground: 210 40% 98%;
-
-    --card: 222.2 84% 4.9%;
-    --card-foreground: 210 40% 98%;
-
-    --border: 217.2 32.6% 17.5%;
-    --input: 217.2 32.6% 17.5%;
-
-    --primary: 210 40% 98%;
-    --primary-foreground: 222.2 47.4% 11.2%;
-
-    --secondary: 217.2 32.6% 17.5%;
-    --secondary-foreground: 210 40% 98%;
-
-    --accent: 217.2 32.6% 17.5%;
-    --accent-foreground: 210 40% 98%;
-
-    --destructive: 0 62.8% 30.6%;
-    --destructive-foreground: 210 40% 98%;
-
-    --ring: 212.7 26.8% 83.9%;
-  }
 }
 
 @layer base {

--- a/src/tailwind.css
+++ b/src/tailwind.css
@@ -7,23 +7,20 @@
     --background: 0 0% 100%;
     --foreground: 222.2 84% 4.9%;
 
-    --muted: 210 40% 96.1%;
-    --muted-foreground: 215.4 16.3% 46.9%;
+    --card: 0 0% 100%;
+    --card-foreground: 222.2 84% 4.9%;
 
     --popover: 0 0% 100%;
     --popover-foreground: 222.2 84% 4.9%;
 
-    --card: 0 0% 100%;
-    --card-foreground: 222.2 84% 4.9%;
-
-    --border: 214.3 31.8% 91.4%;
-    --input: 214.3 31.8% 91.4%;
-
-    --primary: 222.2 47.4% 11.2%;
+    --primary: 221.2 83.2% 53.3%;
     --primary-foreground: 210 40% 98%;
 
     --secondary: 210 40% 96.1%;
     --secondary-foreground: 222.2 47.4% 11.2%;
+
+    --muted: 210 40% 96.1%;
+    --muted-foreground: 215.4 16.3% 46.9%;
 
     --accent: 210 40% 96.1%;
     --accent-foreground: 222.2 47.4% 11.2%;
@@ -31,7 +28,11 @@
     --destructive: 0 84.2% 60.2%;
     --destructive-foreground: 210 40% 98%;
 
-    --ring: 222.2 84% 4.9%;
+    --border: 214.3 31.8% 91.4%;
+
+    --input: 214.3 31.8% 91.4%;
+
+    --ring: 221.2 83.2% 53.3%;
 
     --radius: 0.5rem;
   }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -43,6 +43,12 @@ module.exports = {
         destructive: {
           DEFAULT: "hsl(var(--destructive))",
           foreground: "hsl(var(--destructive-foreground))",
+          50: "#fcefef",
+          100: "#fde8e8",
+          300: "#f7a1a1",
+          700: "#bc1010",
+          900: "#8d0c0c",
+          950: "#5e0808",
         },
         muted: {
           DEFAULT: "hsl(var(--muted))",

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -66,6 +66,27 @@ module.exports = {
           DEFAULT: "hsl(var(--card))",
           foreground: "hsl(var(--card-foreground))",
         },
+        skill1: {
+          DEFAULT: "#ff5544",
+        },
+        skill2: {
+          DEFAULT: "#ff8b43",
+        },
+        skill3: {
+          DEFAULT: "#ffbf43",
+        },
+        skill4: {
+          DEFAULT: "#fff265",
+        },
+        skill5: {
+          DEFAULT: "#c8f17c",
+        },
+        skill6: {
+          DEFAULT: "#8be9b8",
+        },
+        skill7: {
+          DEFAULT: "#59deff",
+        },
       },
       borderRadius: {
         lg: "var(--radius)",

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -29,6 +29,12 @@ module.exports = {
         primary: {
           DEFAULT: "hsl(var(--primary))",
           foreground: "hsl(var(--primary-foreground))",
+          50: "#eff3fc",
+          100: "#d0defb",
+          300: "#8aacf4",
+          700: "#1147bb",
+          900: "#0d358c",
+          950: "#09235d",
         },
         secondary: {
           DEFAULT: "hsl(var(--secondary))",


### PR DESCRIPTION
Addresses parts of #309 

- Set color theme to standard blue from [shadcn themes](https://ui.shadcn.com/themes)
- Removed variables for dark theme
- Added lightness variations to primary color
- Added lightness variations to destructive color
- Added skill / stickFrequency colors. Like the old ones, just lightened up a little
- Added a page to see all theme colors at once. This page will be useful for the follow up changes to the theme. It can be removed once the theme is fully decided

These changes should allow us to start working with shadcn and its theming effectively. Follow up updates are needed to determine what the secondary and accent colors should be (or if they should stay as they are). The skill colors might also be needed in different values / brightnesses but I would suggest we add those as needed.

Here is an image of the most important colors, contained in the Theme-Test-page (can be accessed via `/theme`):
![grafik](https://github.com/bastislack/highline-freestyle/assets/33333283/1f40f5b8-f037-4a0a-9008-037438fd7a8e)
