### PR TITLE
feat(ui): Change shadcn style to default

### DIFF
--- a/components.json
+++ b/components.json
@@ -1,5 +1,5 @@
 {
-  "style": "new-york",
+  "style": "default",
   "typescript": true,
   "tailwind": {
     "config": "tailwind.config.js",


### PR DESCRIPTION
Changed the shadcn style from "New York" to "Default". I find the "Default" style to be a lot more dynamic / energetic in comparison to the more professional looking "New York" style.

The difference between the styles can be explored [here](https://ui.shadcn.com/themes) by clicking on "Customize" in the top right and switching between the two styles.

This is a fairly small change so please let me know what you think of it. If there is no negative feedback by the day after tomorrow I will just merge this.