### PR TITLE
fix(ui): Change dropdown separator color to secondary

### DIFF
--- a/src/components/ui/dropdown-menu/DropdownMenuSeparator.vue
+++ b/src/components/ui/dropdown-menu/DropdownMenuSeparator.vue
@@ -5,5 +5,5 @@ const props = defineProps<DropdownMenuSeparatorProps>();
 </script>
 
 <template>
-  <DropdownMenuSeparator v-bind="props" class="-mx-1 my-1 h-px bg-muted" />
+  <DropdownMenuSeparator v-bind="props" class="-mx-1 my-1 h-px bg-secondary" />
 </template>


### PR DESCRIPTION
Updates the DropdownMenuSeparator color to the `secondary` color to make it consistent with the Separator component and the usage of colors defined in #309. As `muted` (the original color) and `secondary` are of the same color at the moment this has no visual impact right now. It might have an impact though, when / if we update the color theme.