### PR TITLE
fix: change from hash to history router

### DIFF
--- a/src/routes/router.ts
+++ b/src/routes/router.ts
@@ -1,7 +1,7 @@
-import { createRouter, createWebHashHistory } from 'vue-router';
+import { createRouter, createWebHistory } from 'vue-router';
 
 export default createRouter({
-  history: createWebHashHistory(),
+  history: createWebHistory(),
   routes: [
     {
       path: '/',


### PR DESCRIPTION
To get rid of the hash in the route. This is the preferred method according to @WaldemarLehner .