### PR TITLE
feat(ui): improve layout in DefaultLayout with Section component

### DIFF
--- a/src/components/TrickOverview.vue
+++ b/src/components/TrickOverview.vue
@@ -3,6 +3,7 @@
 
 import type { Trick } from '../lib/database/daos/trick';
 import TrickOverviewCard from './TrickOverviewCard.vue';
+import Section from './ui/section/Section.vue';
 
 const allTricks = await (await import('../lib/database')).tricksDao.getAll();
 
@@ -39,7 +40,7 @@ function compareTrickNames(a: Trick, b: Trick) {
 </script>
 
 <template>
-  <div
+  <Section
     v-for="level in Object.keys(tricksByDifficulty)
       .filter((e) => Number(e) >= 0)
       .reverse()"
@@ -57,8 +58,8 @@ function compareTrickNames(a: Trick, b: Trick) {
         :key="trick.primaryKey.join('-')"
       />
     </div>
-  </div>
-  <div v-if="(tricksByDifficulty['-1'] ?? []).length > 0">
+  </Section>
+  <Section v-if="(tricksByDifficulty['-1'] ?? []).length > 0">
     <h2 class="text-2xl font-bold py-2 text-center bg-light-gray border-b border-t border-black">
       To Be Determined
     </h2>
@@ -72,5 +73,5 @@ function compareTrickNames(a: Trick, b: Trick) {
         :key="trick.primaryKey.join('-')"
       />
     </div>
-  </div>
+  </Section>
 </template>

--- a/src/components/ui/section/Section.vue
+++ b/src/components/ui/section/Section.vue
@@ -1,0 +1,7 @@
+<template>
+  <section class="w-full flex flex-col items-center p-3 md:p-5 lg:p-6 xl:px-12">
+    <div class="w-full max-w-4xl">
+      <slot />
+    </div>
+  </section>
+</template>

--- a/src/layouts/DefaultLayout.vue
+++ b/src/layouts/DefaultLayout.vue
@@ -10,7 +10,7 @@ import NavbarBottom from '../components/navbar/NavbarBottom.vue';
         <NavbarSide />
         <div class="w-56" />
       </div>
-      <div>
+      <div class="w-full min-h-screen flex flex-col items-center">
         <slot />
         <div class="block lg:hidden">
           <div class="h-16 w-full" />


### PR DESCRIPTION
Combines two small but important changes to the layout:

1. In the `DefaultLayout` the content did not fill the entire screen. This is now fixed
2. In order to limit the horizontal size of the content of pages consistently across all pages a new `Section` component was added. This can be used by a developer to add their content into. The horizontal size scales with the screen size (while adding padding) until a certain point (only reached on larger screens such as large tablets or on desktops) where the size stays fixed and the content is centered. 