### PR TITLE
fix: rewrite dependency vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5694,14 +5694,15 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.6",
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
+      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "license": "MIT",
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },
@@ -6062,7 +6063,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.29",
+      "version": "8.4.33",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.33.tgz",
+      "integrity": "sha512-Kkpbhhdjw2qQs2O2DGX+8m5OVqEcbB9HRBvuYM9pgrjEFUg30A9LmXNlTAUj4S9kgtGyrMbTzVjH7E+s5Re2yg==",
       "funding": [
         {
           "type": "opencollective",
@@ -6077,9 +6080,8 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.6",
+        "nanoid": "^3.3.7",
         "picocolors": "^1.0.0",
         "source-map-js": "^1.0.2"
       },
@@ -7446,9 +7448,10 @@
       "license": "MIT"
     },
     "node_modules/vite": {
-      "version": "4.4.9",
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.2.tgz",
+      "integrity": "sha512-tBCZBNSBbHQkaGyhGCDUGqeo2ph8Fstyp6FMSvTtsXeZSPpSMGlviAOav2hxVTqFcx8Hj/twtWKsMJXNY0xI8w==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "esbuild": "^0.18.10",
         "postcss": "^8.4.27",
@@ -8145,8 +8148,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.22.2",
-      "license": "MIT",
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.4.tgz",
+      "integrity": "sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "vue": "^3.3.4",
         "vue-i18n": "^9.3.0-beta.27",
         "vue-router": "^4.2.4",
-        "zod": "^3.22.2"
+        "zod": "^3.22.4"
       },
       "devDependencies": {
         "@iconify/vue": "^4.1.1",
@@ -34,13 +34,13 @@
         "globby": "^13.2.2",
         "husky": "^8.0.0",
         "lint-staged": "^15.1.0",
-        "postcss": "^8.4.29",
+        "postcss": "^8.4.33",
         "prettier": "3.1.0",
         "rollup-plugin-visualizer": "^5.9.2",
         "sass": "^1.69.5",
         "tailwindcss": "^3.3.3",
         "typescript": "^5.0.2",
-        "vite": "^4.4.5",
+        "vite": "^4.5.2",
         "vite-node": "^0.34.6",
         "vite-plugin-pwa": "^0.16.5",
         "vue-tsc": "^1.8.5",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "vue": "^3.3.4",
     "vue-i18n": "^9.3.0-beta.27",
     "vue-router": "^4.2.4",
-    "zod": "^3.22.2"
+    "zod": "^3.22.4"
   },
   "devDependencies": {
     "@iconify/vue": "^4.1.1",
@@ -44,13 +44,13 @@
     "globby": "^13.2.2",
     "husky": "^8.0.0",
     "lint-staged": "^15.1.0",
-    "postcss": "^8.4.29",
+    "postcss": "^8.4.33",
     "prettier": "3.1.0",
     "rollup-plugin-visualizer": "^5.9.2",
     "sass": "^1.69.5",
     "tailwindcss": "^3.3.3",
     "typescript": "^5.0.2",
-    "vite": "^4.4.5",
+    "vite": "^4.5.2",
     "vite-node": "^0.34.6",
     "vite-plugin-pwa": "^0.16.5",
     "vue-tsc": "^1.8.5",


### PR DESCRIPTION
Multiple (about 4) vulnerabilities have emerged over time in our dependencies. I ran `npm audit fix` to resolve the issues.