### PR TITLE
fix: proper importing of logo to navbar

### DIFF
--- a/src/components/navbar/NavbarSide.vue
+++ b/src/components/navbar/NavbarSide.vue
@@ -6,6 +6,7 @@ import { Separator } from '@/components/ui/separator';
 import { Button } from '@/components/ui/button';
 import messages from '../../i18n/navbar';
 import { setNewLocale } from '@/util/locale';
+import ImgLogoUrl from '@/assets/logo/logo_big.svg?url';
 
 const i18n = useI18n({
   messages,
@@ -63,7 +64,7 @@ const links: NavLink[] = [
     <div>
       <div class="h-6"></div>
       <RouterLink to="/">
-        <img src="@/assets/logo/logo_big.svg" class="px-4" />
+        <img :src="ImgLogoUrl" class="px-4" />
       </RouterLink>
       <div class="h-4"></div>
       <ul class="flex flex-col gap-1 text-gray-800 font-prose">


### PR DESCRIPTION
Changed the way the logo is imported in the SideNavbar. The previous way, supposedly, had the potential to, while working in the development environment, not work in production.

This is such a minor change that I will merge without review.