### PR TITLE
fix: navbar active tab highlighted on sub routes

### DIFF
--- a/src/routes/router.ts
+++ b/src/routes/router.ts
@@ -5,7 +5,7 @@ export default createRouter({
   routes: [
     {
       path: '/',
-      component: () => import('./IndexRoute.vue'),
+      redirect: '/tricks',
     },
     {
       path: '/dbtest',
@@ -18,9 +18,17 @@ export default createRouter({
       component: () => import('./ThemeTest.vue'),
     },
     {
-      path: '/tricks/:status/:id',
-      name: 'Trick Details',
-      component: () => import('./tricks/TrickDetails.vue'),
+      path: '/tricks',
+      children: [
+        {
+          path: '',
+          component: () => import('./IndexRoute.vue'),
+        },
+        {
+          path: ':status/:id',
+          component: () => import('./tricks/TrickDetails.vue'),
+        },
+      ],
     },
     {
       path: '/:catchAll(.*)',


### PR DESCRIPTION
Closes #335.

The issue was not with the navbar but with how the routes in `src/router/router.ts` were set up. It turns out that `active` on router lines does not look at the URL open but at the structure of the router. So `/tricks/official/3` is not automatically considered to be a sub route of `/tricks`. It only is, if The router is set up in such a way that `/tricks/:status/:id` is a child route of `/tricks` (look at the changes for this, then it will become more clear what I mean).

Since I was at it, I also added a redirect from `/` to `/tricks`. We were already displaying the TrickList at `/` and it would be more intuitive and appropriate to display it at `/tricks` while it still being the landing page.