### PR TITLE
Add secondary color values

### DIFF
--- a/src/tailwind.css
+++ b/src/tailwind.css
@@ -16,8 +16,8 @@
     --primary: 221.2 83.2% 53.3%;
     --primary-foreground: 210 40% 98%;
 
-    --secondary: 210 40% 96.1%;
-    --secondary-foreground: 222.2 47.4% 11.2%;
+    --secondary: 220 14% 96%;
+    --secondary-foreground: 221 39% 11%;
 
     --muted: 210 40% 96.1%;
     --muted-foreground: 215.4 16.3% 46.9%;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -37,8 +37,16 @@ module.exports = {
           950: "#09235d",
         },
         secondary: {
+          // Color values are derived from the tailwindcss "gray" class
           DEFAULT: "hsl(var(--secondary))",
           foreground: "hsl(var(--secondary-foreground))",
+          50: "#f9fafb",
+          100: "#f3f4f6",
+          300: "#d1d5db",
+          500: "#6b7280",
+          700: "#374151",
+          900: "#111827",
+          950: "#030712",
         },
         destructive: {
           DEFAULT: "hsl(var(--destructive))",


### PR DESCRIPTION
- Shifted the secondary color ever so slightly to a warmer tone (equal to the tailwindcss "gray" class)
- Added shades 50, 100, 300, 500, 700, 900 and 950 to secondary color

I will from now on consider the secondary class as the default one to use when gray colors are needed.