### PR TITLE
Refactor and fix: Use central types instead of hard coded ones

### DIFF
--- a/src/components/stickable/ArchivedDecisionDialog.vue
+++ b/src/components/stickable/ArchivedDecisionDialog.vue
@@ -14,6 +14,7 @@ import { useToast } from '../ui/toast';
 import router from '@/routes/router';
 import { useI18n } from 'vue-i18n';
 import messages from '@/i18n/tricks/archivedDialogue';
+import { StickableStatus } from '@/lib/utils';
 
 const i18n = useI18n({
   messages,
@@ -24,7 +25,7 @@ const { t } = i18n;
 
 const props = defineProps<{
   trickName: string;
-  trickStatus: 'archived' | 'official' | 'userDefined';
+  trickStatus: StickableStatus;
   trickId: number;
 }>();
 

--- a/src/components/stickable/trick/DeleteTrickDialog.vue
+++ b/src/components/stickable/trick/DeleteTrickDialog.vue
@@ -15,6 +15,7 @@ import { tricksDao } from '@/lib/database';
 import router from '@/routes/router';
 import { useI18n } from 'vue-i18n';
 import messages from '@/i18n/tricks/delete';
+import { StickableStatus } from '@/lib/utils';
 
 const i18n = useI18n({
   messages,
@@ -25,7 +26,7 @@ const { t } = i18n;
 
 let props = defineProps<{
   trickName: string;
-  trickStatus: 'archived' | 'official' | 'userDefined';
+  trickStatus: StickableStatus;
   trickId: number;
 }>();
 

--- a/src/components/stickable/trick/TrickDetailsContent.vue
+++ b/src/components/stickable/trick/TrickDetailsContent.vue
@@ -15,9 +15,10 @@ import ErrorInfo from '@/components/ErrorInfo.vue';
 import Separator from '@/components/ui/separator/Separator.vue';
 import Button from '@/components/ui/button/Button.vue';
 import ArchivedDecisionDialog from '@/components/stickable/ArchivedDecisionDialog.vue';
+import { StickableStatus } from '@/lib/utils';
 
 const props = defineProps<{
-  status: 'official' | 'userDefined' | 'archived';
+  status: StickableStatus;
   id: number;
 }>();
 

--- a/src/lib/database/schemas/Version1Schema.ts
+++ b/src/lib/database/schemas/Version1Schema.ts
@@ -28,7 +28,7 @@ export const DbPositionZod = z.enum([
 export const DbStickableStatusZod = z.enum(['official', 'userDefined', 'archived']);
 
 // [id, trickStatus] OR [id, comboStatus]
-const DbReferenceZod = z.tuple([z.number().int(), DbStickableStatusZod]);
+export const DbReferenceZod = z.tuple([z.number().int(), DbStickableStatusZod]);
 
 export const DbVideoZod = z.object({
   link: z.string().nonempty().url(),

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,12 +1,14 @@
 import { type ClassValue, clsx } from 'clsx';
 import { twMerge } from 'tailwind-merge';
+import { z } from 'zod';
+import { DbStickableStatusZod, DbReferenceZod } from '@/lib/database/schemas/CurrentVersionSchema';
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
 
-type StickableStatus = 'official' | 'userDefined' | 'archived';
-type PrimaryKey = [number, StickableStatus];
+export type StickableStatus = z.infer<typeof DbStickableStatusZod>;
+export type PrimaryKey = z.infer<typeof DbReferenceZod>;
 
 export function primaryKeysMatch(pk1: Readonly<PrimaryKey>, pk2: Readonly<PrimaryKey>): boolean {
   return pk1[0] === pk2[0] && pk1[1] === pk2[1];


### PR DESCRIPTION
- Moved statical `"official" | "archived" | "userDefined"` typings into one central `StickableStatus` type. Same for `PrimaryKey` which is `[number, StickableStatus]`. Both `PrimaryKey` and `StickableStatus` are now based on the current Schema definition of them.
- Fixed a very improbable though possible bug in `trick.ts` which could allow two persist operations to run simultaneously