### PR TITLE
Update browserlist

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3345,9 +3345,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001557",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001557.tgz",
-      "integrity": "sha512-91oR7hLNUP3gG6MLU+n96em322a8Xzes8wWdBKhLgUoiJsAF5irZnxSUCbc+qUZXNnPCfUwLOi9ZCZpkvjQajw==",
+      "version": "1.0.30001687",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001687.tgz",
+      "integrity": "sha512-0S/FDhf4ZiqrTUiQ39dKeUjYRjkv7lOZU1Dgif2rIqrTzX/1wV2hfKu9TOm1IHkdSijfLswxTFzl/cvir+SLSQ==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
For a while, when running `npm run dev` a prompt appeared to update the browserlist:
```
Browserslist: caniuse-lite is outdated. Please run:
  npx update-browserslist-db@latest
  Why you should do it regularly: https://github.com/browserslist/update-db#readme
```
Therefore I updated it with
```bash
npx update-browserslist-db@latest
```