### PR TITLE
feat: add button to set stickable as favorite

### DIFF
--- a/src/components/stickable/Header.vue
+++ b/src/components/stickable/Header.vue
@@ -23,7 +23,9 @@ function hasHistory(): boolean {
         <slot></slot>
       </div>
 
-      <slot name="buttonRight" class="h-6 w-6"></slot>
+      <div class="h-fit w-fit flex flex-row justify-end gap-0">
+        <slot name="buttonsRight"></slot>
+      </div>
     </div>
   </section>
 </template>

--- a/src/components/stickable/IsFavoriteToggle.vue
+++ b/src/components/stickable/IsFavoriteToggle.vue
@@ -1,0 +1,95 @@
+<script setup lang="ts">
+import { combosDao, tricksDao } from '@/lib/database';
+import { StickableStatus, StickableType } from '@/lib/utils';
+import { computed, ref } from 'vue';
+import { useToast } from '@/components/ui/toast';
+import { onboardingTipHasBeenShown, setOnboardingTipAsShown } from '@/util/onboarding';
+import { useI18n } from 'vue-i18n';
+import messages from '@/i18n/metadata/favorite';
+
+import Button from '@/components/ui/button/Button.vue';
+import { Icon } from '@iconify/vue/dist/iconify.js';
+
+const props = defineProps<{
+  id: number;
+  status: StickableStatus;
+  stickableType: StickableType;
+}>();
+
+const { toast } = useToast();
+
+const i18n = useI18n({
+  messages,
+  useScope: 'local',
+});
+const { t } = i18n;
+
+const isFavorite = ref<boolean>(false);
+
+async function setButtonStateToDBState() {
+  if (props.stickableType === 'Trick') {
+    const trick = await tricksDao.getById(props.id, props.status);
+    if (trick === undefined) {
+      throw new Error(`Could not locate trick with id in database: [${props.id}, ${props.status}]`);
+    }
+    isFavorite.value = trick.isFavourite;
+  } else if (props.stickableType === 'Combo') {
+    const combo = await combosDao.getById(props.id, props.status);
+    if (combo === undefined) {
+      throw new Error(`Could not locate combo with id in database: [${props.id}, ${props.status}]`);
+    }
+    isFavorite.value = combo.isFavourite;
+  }
+}
+
+async function toggleFavorite() {
+  if (props.stickableType === 'Trick') {
+    await toggleFavoriteTrick();
+  } else if (props.stickableType === 'Combo') {
+    await toggleFavoriteCombo();
+  }
+
+  if (isFavorite.value && !onboardingTipHasBeenShown('SetFavorite')) {
+    toast({
+      title: t('onboardingInfo.titel'),
+      description: t(
+        props.stickableType == 'Trick'
+          ? 'onboardingInfo.descriptionTrick'
+          : 'onboardingInfo.descriptionCombo'
+      ),
+      duration: 9000,
+    });
+    setOnboardingTipAsShown('SetFavorite');
+  }
+}
+
+async function toggleFavoriteTrick() {
+  const trick = await tricksDao.getById(props.id, props.status);
+  if (trick === undefined) {
+    throw new Error(`Could not locate trick with id in database: [${props.id}, ${props.status}]`);
+  }
+  trick.isFavourite = !trick.isFavourite;
+  await trick.persist();
+  isFavorite.value = trick.isFavourite;
+}
+
+async function toggleFavoriteCombo() {
+  const combo = await combosDao.getById(props.id, props.status);
+  if (combo === undefined) {
+    throw new Error(`Could not locate combo with id in database: [${props.id}, ${props.status}]`);
+  }
+  combo.isFavourite = !combo.isFavourite;
+  await combo.persist();
+  isFavorite.value = combo.isFavourite;
+}
+
+const icon = computed(() => (isFavorite.value ? 'ic:round-star' : 'ic:round-star-border'));
+
+setButtonStateToDBState();
+</script>
+
+<template>
+  <Button size="icon" variant="ghost" @click="toggleFavorite" class="rounded-full">
+    <Icon :icon="icon" class="h-7 w-7 text-primary" />
+  </Button>
+</template>

--- a/src/components/stickable/trick/TrickDetailsContent.vue
+++ b/src/components/stickable/trick/TrickDetailsContent.vue
@@ -16,6 +16,7 @@ import Separator from '@/components/ui/separator/Separator.vue';
 import Button from '@/components/ui/button/Button.vue';
 import ArchivedDecisionDialog from '@/components/stickable/ArchivedDecisionDialog.vue';
 import { StickableStatus } from '@/lib/utils';
+import IsFavoriteToggle from '../IsFavoriteToggle.vue';
 
 const props = defineProps<{
   status: StickableStatus;
@@ -119,10 +120,11 @@ watchEffect(async () => {
       <Header>
         {{ trick.alias ?? trick.technicalName }}
 
-        <template #buttonRight>
+        <template #buttonsRight>
           <Button size="icon" variant="ghost" disabled>
             <Icon icon="ic:round-edit" class="h-6 w-6 text-primary" />
           </Button>
+          <IsFavoriteToggle stickable-type="Trick" :id="id" :status="status" />
         </template>
       </Header>
       <Section class="mt-1 lg:mt-0">

--- a/src/i18n/metadata/favorite/favorite.en.json
+++ b/src/i18n/metadata/favorite/favorite.en.json
@@ -1,0 +1,7 @@
+{
+  "onboardingInfo": {
+    "titel": "Set as favorite.",
+    "descriptionTrick": "This can mean whatever you like and primarily makes finding this trick easier.",
+    "descriptionCombo": "This can mean whatever you like and primarily makes finding this combo easier."
+  }
+}

--- a/src/i18n/metadata/favorite/favorite.es.json
+++ b/src/i18n/metadata/favorite/favorite.es.json
@@ -1,0 +1,7 @@
+{
+  "onboardingInfo": {
+    "titel": "Establecer como favorito.",
+    "descriptionTrick": "Esto puede significar lo que quieras y principalmente hace que encontrar este truco sea más fácil.",
+    "descriptionCombo": "Esto puede significar lo que quieras y principalmente hace que encontrar esta combo sea más fácil."
+  }
+}

--- a/src/i18n/metadata/favorite/favorite.fr.json
+++ b/src/i18n/metadata/favorite/favorite.fr.json
@@ -1,0 +1,7 @@
+{
+  "onboardingInfo": {
+    "titel": "Définir comme favori.",
+    "descriptionTrick": "Cela peut signifier ce que vous voulez et facilite la recherche de cette trick.",
+    "descriptionCombo": "Cela peut signifier ce que vous voulez et facilite la recherche de cette combo."
+  }
+}

--- a/src/i18n/metadata/favorite/index.ts
+++ b/src/i18n/metadata/favorite/index.ts
@@ -1,0 +1,9 @@
+import en from './favorite.en.json';
+import es from './favorite.es.json';
+import fr from './favorite.fr.json';
+
+export default {
+  en,
+  es,
+  fr,
+};

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,7 +1,11 @@
 import { type ClassValue, clsx } from 'clsx';
 import { twMerge } from 'tailwind-merge';
 import { z } from 'zod';
-import { DbStickableStatusZod, DbReferenceZod } from '@/lib/database/schemas/CurrentVersionSchema';
+import {
+  DbStickableStatusZod,
+  DbReferenceZod,
+  DbMetadataZod,
+} from '@/lib/database/schemas/CurrentVersionSchema';
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
@@ -9,6 +13,7 @@ export function cn(...inputs: ClassValue[]) {
 
 export type StickableStatus = z.infer<typeof DbStickableStatusZod>;
 export type PrimaryKey = z.infer<typeof DbReferenceZod>;
+export type StickableType = z.infer<typeof DbMetadataZod>['entityCategory'];
 
 export function primaryKeysMatch(pk1: Readonly<PrimaryKey>, pk2: Readonly<PrimaryKey>): boolean {
   return pk1[0] === pk2[0] && pk1[1] === pk2[1];

--- a/src/util/onboarding.ts
+++ b/src/util/onboarding.ts
@@ -1,0 +1,11 @@
+type OnboardTipKey = 'SetFavorite';
+
+export function onboardingTipHasBeenShown(tipKey: OnboardTipKey) {
+  const full_key = `ONBOARDING_HAS_BEEN_SHOWN_${tipKey}`;
+  return window.localStorage.getItem(full_key) !== null;
+}
+
+export function setOnboardingTipAsShown(tipKey: OnboardTipKey) {
+  const full_key = `ONBOARDING_HAS_BEEN_SHOWN_${tipKey}`;
+  window.localStorage.setItem(full_key, 'true');
+}


### PR DESCRIPTION
Addresses #294

## Features
- The Trick Details page now has a litte star button in the header to set the trick as a favorite trick (/ to undo this action by clicking the button again)
- When clicking the button for the first time a toast is shown explaining, what "Favorite" means in this context. After that the toast is never shown again.

## Notes
- This required minor changes to the header as it was initially only designed to take on button on the right
- util-functions were added to make it possible to only show the onboarding toast once

## What it looks like:
![Screen Shot 2024-12-08 at 13 52 58](https://github.com/user-attachments/assets/b38b0134-cab7-4335-8b92-11d2099b9440)
