### PR TITLE
feat: filter by type

### DIFF
--- a/src/components/stickable/list/TrickSearchMenu.vue
+++ b/src/components/stickable/list/TrickSearchMenu.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, watchEffect } from 'vue';
+import { computed, ref, watchEffect } from 'vue';
 import {
   Select,
   SelectContent,
@@ -13,6 +13,12 @@ import { Input } from '@/components/ui/input';
 import { SearchParameters, SortOrder } from '@/types/search';
 import { useI18n } from 'vue-i18n';
 import messages from '@/i18n/searchMenu';
+import DropdownMenu from '@/components/ui/dropdown-menu/DropdownMenu.vue';
+import DropdownMenuTrigger from '@/components/ui/dropdown-menu/DropdownMenuTrigger.vue';
+import DropdownMenuContent from '@/components/ui/dropdown-menu/DropdownMenuContent.vue';
+import DropdownMenuCheckboxItem from '@/components/ui/dropdown-menu/DropdownMenuCheckboxItem.vue';
+import Button from '@/components/ui/button/Button.vue';
+import { StickableStatus } from '@/lib/utils';
 
 const { t } = useI18n({
   messages,
@@ -24,6 +30,8 @@ const searchParameters = defineModel<SearchParameters>('searchParameters');
 if (searchParameters.value === undefined) {
   throw new Error('Search Parameters model needs to be passed to TrickSearchMenu!');
 }
+
+// SORTING
 
 const sortingOptions: { titleKey: string; directionTitleKey?: string; value: SortOrder }[] = [
   {
@@ -57,31 +65,88 @@ watchEffect(async () => {
   }
   searchParameters.value.sortOrder = activeSortingOption.value;
 });
+
+// STATUS
+
+function updateIncludedStatuses(status: StickableStatus) {
+  if (searchParameters.value?.includedStatuses.includes(status)) {
+    const newIncludedStatuses = searchParameters.value.includedStatuses.filter(
+      (element) => element !== status
+    );
+    if (newIncludedStatuses.length > 0) {
+      searchParameters.value.includedStatuses = newIncludedStatuses;
+    }
+    return;
+  }
+  searchParameters.value?.includedStatuses.push(status);
+}
+
+const includedStatusesTriggerVariant = computed(() => {
+  const allOptionsChecked =
+    searchParameters.value?.includedStatuses.includes('official') &&
+    searchParameters.value?.includedStatuses.includes('userDefined') &&
+    searchParameters.value?.includedStatuses.includes('archived');
+  return allOptionsChecked ? 'secondary' : 'default';
+});
 </script>
 
 <template>
-  <div class="flex flex-row gap-1 w-full h-fit">
-    <div class="grow">
-      <Input :placeholder="t('textSearchPlaceholder')" />
+  <section class="flex flex-col gap-1">
+    <div class="flex flex-row gap-1 w-full h-fit">
+      <div class="grow">
+        <Input :placeholder="t('textSearchPlaceholder')" />
+      </div>
+
+      <div class="w-[175px] flex-initial">
+        <Select v-model="activeSortingOption">
+          <SelectTrigger class="w-[175px] grow-0 shrink-0">
+            <SelectValue placeholder="Select a fruit" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectGroup>
+              <SelectLabel>{{ t('sortOptionsLabel') }}</SelectLabel>
+              <SelectItem
+                v-for="option in sortingOptions"
+                :value="option.value"
+                :key="option.value"
+              >
+                {{ t(option.titleKey) }}
+                <span v-if="option.directionTitleKey" class="text-muted-foreground">
+                  {{ t(option.directionTitleKey) }}
+                </span>
+              </SelectItem>
+            </SelectGroup>
+          </SelectContent>
+        </Select>
+      </div>
     </div>
 
-    <div class="w-[175px] flex-initial">
-      <Select v-model="activeSortingOption">
-        <SelectTrigger class="w-[175px] grow-0 shrink-0">
-          <SelectValue placeholder="Select a fruit" />
-        </SelectTrigger>
-        <SelectContent>
-          <SelectGroup>
-            <SelectLabel>{{ t('sortOptionsLabel') }}</SelectLabel>
-            <SelectItem v-for="option in sortingOptions" :value="option.value" :key="option.value">
-              {{ t(option.titleKey) }}
-              <span v-if="option.directionTitleKey" class="text-muted-foreground">
-                {{ t(option.directionTitleKey) }}
-              </span>
-            </SelectItem>
-          </SelectGroup>
-        </SelectContent>
-      </Select>
+    <div class="flex flex-row gap-1 w-full">
+      <DropdownMenu>
+        <DropdownMenuTrigger as-child>
+          <Button :variant="includedStatusesTriggerVariant" size="sm"> Status </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent>
+          <DropdownMenuCheckboxItem
+            :checked="searchParameters?.includedStatuses.includes('official')"
+            @update:checked="updateIncludedStatuses('official')"
+          >
+            Official
+          </DropdownMenuCheckboxItem>
+          <DropdownMenuCheckboxItem
+            :checked="searchParameters?.includedStatuses.includes('userDefined')"
+            @update:checked="updateIncludedStatuses('userDefined')"
+          >
+            Personal
+          </DropdownMenuCheckboxItem>
+          <DropdownMenuCheckboxItem
+            :checked="searchParameters?.includedStatuses.includes('archived')"
+            @update:checked="updateIncludedStatuses('archived')"
+          >
+            Archived
+          </DropdownMenuCheckboxItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
     </div>
-  </div>
+  </section>
 </template>

--- a/src/components/stickable/list/TrickSearchMenu.vue
+++ b/src/components/stickable/list/TrickSearchMenu.vue
@@ -11,17 +11,19 @@ import {
 } from '@/components/ui/select';
 import { Input } from '@/components/ui/input';
 import { SearchParameters, SortOrder } from '@/types/search';
-import { useI18n } from 'vue-i18n';
-import messages from '@/i18n/searchMenu';
 import DropdownMenu from '@/components/ui/dropdown-menu/DropdownMenu.vue';
 import DropdownMenuTrigger from '@/components/ui/dropdown-menu/DropdownMenuTrigger.vue';
 import DropdownMenuContent from '@/components/ui/dropdown-menu/DropdownMenuContent.vue';
 import DropdownMenuCheckboxItem from '@/components/ui/dropdown-menu/DropdownMenuCheckboxItem.vue';
 import Button from '@/components/ui/button/Button.vue';
 import { StickableStatus } from '@/lib/utils';
+import { useI18n } from 'vue-i18n';
+import { i18nMerge } from '@/i18n/i18nmerge';
+import messages from '@/i18n/searchMenu';
+import messagesStickableStatus from '@/i18n/common/stickableStatus';
 
 const { t } = useI18n({
-  messages,
+  messages: i18nMerge(messages, messagesStickableStatus),
   useScope: 'local',
 });
 
@@ -124,26 +126,28 @@ const includedStatusesTriggerVariant = computed(() => {
     <div class="flex flex-row gap-1 w-full">
       <DropdownMenu>
         <DropdownMenuTrigger as-child>
-          <Button :variant="includedStatusesTriggerVariant" size="sm"> Status </Button>
+          <Button :variant="includedStatusesTriggerVariant" size="sm">
+            {{ t('includedStickableStatuses.triggerTitle') }}
+          </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent>
           <DropdownMenuCheckboxItem
             :checked="searchParameters?.includedStatuses.includes('official')"
             @update:checked="updateIncludedStatuses('official')"
           >
-            Official
+            {{ t('official') }}
           </DropdownMenuCheckboxItem>
           <DropdownMenuCheckboxItem
             :checked="searchParameters?.includedStatuses.includes('userDefined')"
             @update:checked="updateIncludedStatuses('userDefined')"
           >
-            Personal
+            {{ t('userDefined') }}
           </DropdownMenuCheckboxItem>
           <DropdownMenuCheckboxItem
             :checked="searchParameters?.includedStatuses.includes('archived')"
             @update:checked="updateIncludedStatuses('archived')"
           >
-            Archived
+            {{ t('archived') }}
           </DropdownMenuCheckboxItem>
         </DropdownMenuContent>
       </DropdownMenu>

--- a/src/i18n/common/stickableStatus/index.ts
+++ b/src/i18n/common/stickableStatus/index.ts
@@ -1,0 +1,5 @@
+import en from './stickableStatus.en.json';
+import es from './stickableStatus.es.json';
+import fr from './stickableStatus.fr.json';
+
+export default { en, es, fr };

--- a/src/i18n/common/stickableStatus/stickableStatus.en.json
+++ b/src/i18n/common/stickableStatus/stickableStatus.en.json
@@ -1,0 +1,5 @@
+{
+  "official": "Official",
+  "userDefined": "Personal",
+  "archived": "Archived"
+}

--- a/src/i18n/common/stickableStatus/stickableStatus.es.json
+++ b/src/i18n/common/stickableStatus/stickableStatus.es.json
@@ -1,0 +1,5 @@
+{
+  "official": "Oficial",
+  "userDefined": "Personal",
+  "archived": "Archivado"
+}

--- a/src/i18n/common/stickableStatus/stickableStatus.fr.json
+++ b/src/i18n/common/stickableStatus/stickableStatus.fr.json
@@ -1,0 +1,5 @@
+{
+  "official": "Officielle",
+  "userDefined": "Personnel",
+  "archived": "Archivé"
+}

--- a/src/i18n/list/list.en.json
+++ b/src/i18n/list/list.en.json
@@ -10,5 +10,8 @@
       "archived": "Archived",
       "new": "New"
     }
+  },
+  "info": {
+    "noTrickMatchingSearch": "Oh no. There are not tricks matching your search input."
   }
 }

--- a/src/i18n/list/list.es.json
+++ b/src/i18n/list/list.es.json
@@ -10,5 +10,8 @@
       "archived": "Archivado",
       "new": "Nuevo"
     }
+  },
+  "info": {
+    "noTrickMatchingSearch": "Oh, no. No hay trucos que coincidan con su búsqueda."
   }
 }

--- a/src/i18n/list/list.fr.json
+++ b/src/i18n/list/list.fr.json
@@ -10,5 +10,8 @@
       "archived": "Archivé",
       "new": "Nouveau"
     }
+  },
+  "info": {
+    "noTrickMatchingSearch": "Oh non. Il n'y a pas de tricks correspondant à votre recherche."
   }
 }

--- a/src/i18n/searchMenu/searchMenu.en.json
+++ b/src/i18n/searchMenu/searchMenu.en.json
@@ -8,5 +8,8 @@
     "inventionYear": "Invention year",
     "ascending": "Up",
     "descending": "Down"
+  },
+  "includedStickableStatuses": {
+    "triggerTitle": "Status"
   }
 }

--- a/src/i18n/searchMenu/searchMenu.es.json
+++ b/src/i18n/searchMenu/searchMenu.es.json
@@ -8,5 +8,8 @@
     "inventionYear": "Intenvtion year",
     "ascending": "Arriba",
     "descending": "Abajo"
+  },
+  "includedStickableStatuses": {
+    "triggerTitle": "Estado"
   }
 }

--- a/src/i18n/searchMenu/searchMenu.fr.json
+++ b/src/i18n/searchMenu/searchMenu.fr.json
@@ -8,5 +8,8 @@
     "inventionYear": "Année d'invention",
     "ascending": "Haut",
     "descending": "Bas"
+  },
+  "includedStickableStatuses": {
+    "triggerTitle": "Statut"
   }
 }

--- a/src/routes/tricks/TrickList.vue
+++ b/src/routes/tricks/TrickList.vue
@@ -93,6 +93,17 @@ function linkToDetails(primaryKey: PrimaryKey): string {
 
     <Section>
       <div class="w-full flex flex-col gap-5">
+        <div v-if="!searchResult || searchResult.length == 0" class="text-xl text-center mt-3">
+          Oh no. There are not tricks matching your search input.<br /><span class="font-semibold"
+            >:(</span
+          >
+          <div class="flex flex-row justify-center mt-3">
+            <img
+              src="https://media1.tenor.com/m/XQLVLptLIBEAAAAd/maes-b-lost-in-a-field.gif"
+              class="w-48"
+            />
+          </div>
+        </div>
         <div
           v-for="section in searchResult"
           class="w-full flex flex-col gap-1"

--- a/src/routes/tricks/TrickList.vue
+++ b/src/routes/tricks/TrickList.vue
@@ -93,10 +93,10 @@ function linkToDetails(primaryKey: PrimaryKey): string {
 
     <Section>
       <div class="w-full flex flex-col gap-5">
+        <!-- No Search Results-->
         <div v-if="!searchResult || searchResult.length == 0" class="text-xl text-center mt-3">
-          Oh no. There are not tricks matching your search input.<br /><span class="font-semibold"
-            >:(</span
-          >
+          {{ t('info.noTrickMatchingSearch') }}<br />
+          <span class="font-semibold"> :( </span>
           <div class="flex flex-row justify-center mt-3">
             <img
               src="https://media1.tenor.com/m/XQLVLptLIBEAAAAd/maes-b-lost-in-a-field.gif"
@@ -104,6 +104,8 @@ function linkToDetails(primaryKey: PrimaryKey): string {
             />
           </div>
         </div>
+
+        <!-- Search Results-->
         <div
           v-for="section in searchResult"
           class="w-full flex flex-col gap-1"

--- a/src/routes/tricks/TrickList.vue
+++ b/src/routes/tricks/TrickList.vue
@@ -24,14 +24,23 @@ const i18n = useI18n({
 const { t } = i18n;
 
 const LOCAL_STORAGE_PARAMETERS_KEY: string = 'SearchParameters-Tricks';
-const DEFAULT_SEARCH_PARAMETERS: SearchParameters = { sortOrder: 'difficulty-asc' };
+const DEFAULT_SEARCH_PARAMETERS: SearchParameters = {
+  sortOrder: 'difficulty-asc',
+  includedStatuses: ['official', 'userDefined', 'archived'],
+};
 
 function loadSearchParameters(): SearchParameters {
   const parametersAsString = window.localStorage.getItem(LOCAL_STORAGE_PARAMETERS_KEY);
   if (!parametersAsString) {
     return DEFAULT_SEARCH_PARAMETERS;
   }
-  return JSON.parse(parametersAsString);
+
+  const parameters = JSON.parse(parametersAsString);
+  parameters.sortOrder = parameters.sortOrder || DEFAULT_SEARCH_PARAMETERS.sortOrder;
+  parameters.includedStatuses =
+    parameters.includedStatuses || DEFAULT_SEARCH_PARAMETERS.includedStatuses;
+
+  return parameters;
 }
 
 function storeSearchParameters(parameters: SearchParameters) {

--- a/src/services/searchAndFilterTricks.ts
+++ b/src/services/searchAndFilterTricks.ts
@@ -66,6 +66,9 @@ function groupTricksToSearchResult(
   sorting: SortOrder,
   mapTrickToAttribute: (t: Trick, sort: SortOrder) => string
 ): SearchResult {
+  if (sortedTricks.length === 0) {
+    return [];
+  }
   let currentGroup = mapTrickToAttribute(sortedTricks[0], sorting);
   const result: SearchResult = [{ title: currentGroup, items: [] }];
 
@@ -85,7 +88,11 @@ export function searchInTricks(
   searchParameters: SearchParameters,
   mapTrickToAttribute: (t: Trick, sort: SortOrder) => string
 ): SearchResult {
-  const sortedTricks = sortTricks(allTricks, searchParameters.sortOrder);
+  const filteredTricks = allTricks.filter((trick) =>
+    searchParameters.includedStatuses.includes(trick.primaryKey[1])
+  );
+
+  const sortedTricks = sortTricks(filteredTricks, searchParameters.sortOrder);
   const searchResult = groupTricksToSearchResult(
     sortedTricks,
     searchParameters.sortOrder,

--- a/src/types/search.ts
+++ b/src/types/search.ts
@@ -1,4 +1,4 @@
-import { PrimaryKey } from '@/lib/utils';
+import { PrimaryKey, StickableStatus } from '@/lib/utils';
 
 export type SearchResult = SearchSection[];
 
@@ -26,4 +26,5 @@ export type SortOrder =
 export type SearchParameters = {
   searchText?: string;
   sortOrder: SortOrder;
+  includedStatuses: StickableStatus[];
 };


### PR DESCRIPTION
Addresses #297

# Features
- Checkbox style selection to see Official, Personal and / or Archived tricks (in a Dropdown Menu)
- If one or more categories are deselected, the trigger button for the dropdown turns from the secondary to the primary color to indicate that a filter is active within this option
- At least one category needs to be selected at all times (the user can not deselect the last remaining one)
- If any filtering results in no tricks matching the filters a message is telling the user about this fact so that it is clear what has happened and the user does not incorrectly get the impression that an error has occurred (so far this resulted in a blank page below the search options)
- Internationalized into English, Spanish and French

# Screenshot
(The button is only blue if one or more categories are deselected / the result is actually filtered by this option). Otherwise it is grey.
![Screen Shot 2025-01-27 at 15 44 27](https://github.com/user-attachments/assets/7bbd903b-ea87-4f0b-8cab-0b1966bcacfe)

