### PR TITLE
feat: search by name

### DIFF
--- a/src/components/stickable/list/TrickSearchMenu.vue
+++ b/src/components/stickable/list/TrickSearchMenu.vue
@@ -21,6 +21,7 @@ import { useI18n } from 'vue-i18n';
 import { i18nMerge } from '@/i18n/i18nmerge';
 import messages from '@/i18n/searchMenu';
 import messagesStickableStatus from '@/i18n/common/stickableStatus';
+import { Icon } from '@iconify/vue/dist/iconify.js';
 
 const { t } = useI18n({
   messages: i18nMerge(messages, messagesStickableStatus),
@@ -90,17 +91,49 @@ const includedStatusesTriggerVariant = computed(() => {
     searchParameters.value?.includedStatuses.includes('archived');
   return allOptionsChecked ? 'secondary' : 'default';
 });
+
+// TEXT SEARCH
+
+function resetSearchText() {
+  if (searchParameters.value !== undefined) {
+    searchParameters.value.searchText = undefined;
+  }
+}
+
+function setSearchText(text: string | number) {
+  if (searchParameters.value !== undefined) {
+    searchParameters.value.searchText = text.toString();
+  }
+}
+
+const textSearchContainsText = computed<boolean>(() => {
+  return searchParameters.value !== undefined && !!searchParameters.value.searchText;
+});
 </script>
 
 <template>
   <section class="flex flex-col gap-1">
     <div class="flex flex-row gap-1 w-full h-fit">
-      <div class="grow">
-        <Input :placeholder="t('textSearchPlaceholder')" />
+      <div class="grow relative">
+        <Input
+          :placeholder="t('textSearchPlaceholder')"
+          class="pr-10"
+          :model-value="searchParameters?.searchText"
+          v-on:update:model-value="setSearchText"
+        />
+        <Button
+          v-if="textSearchContainsText"
+          variant="ghost"
+          size="icon"
+          class="absolute top-0 right-0"
+          :onclick="resetSearchText"
+        >
+          <Icon icon="ic:round-close" class="h-5 w-5" />
+        </Button>
       </div>
 
       <div class="w-[175px] flex-initial">
-        <Select v-model="activeSortingOption">
+        <Select v-model="activeSortingOption" :disabled="textSearchContainsText">
           <SelectTrigger class="w-[175px] grow-0 shrink-0">
             <SelectValue placeholder="Select a fruit" />
           </SelectTrigger>
@@ -125,7 +158,7 @@ const includedStatusesTriggerVariant = computed(() => {
 
     <div class="flex flex-row gap-1 w-full">
       <DropdownMenu>
-        <DropdownMenuTrigger as-child>
+        <DropdownMenuTrigger as-child :disabled="textSearchContainsText">
           <Button :variant="includedStatusesTriggerVariant" size="sm">
             {{ t('includedStickableStatuses.triggerTitle') }}
           </Button>

--- a/src/services/searchAndFilterTricks.ts
+++ b/src/services/searchAndFilterTricks.ts
@@ -2,6 +2,8 @@ import { Trick } from '@/lib/database/daos/trick';
 import { SearchItem, SearchParameters, SearchResult, SortOrder } from '@/types/search';
 import { isStickableNew } from '@/util/misc';
 
+type TrickNameToUse = 'alias' | 'technical';
+
 function equalLengthStringDistance(a: string, b: string): number {
   if (a.length !== b.length) {
     throw new Error('Both strings need to be of equal length.');
@@ -41,22 +43,41 @@ function textDistance(baseText: string, query: string): number {
   return minDist + unmatchedCharactersPenalty;
 }
 
-function trickNameDistance(trick: Trick, query: string): number {
+function trickNameDistance(
+  trick: Trick,
+  query: string
+): { distance: number; nameToUse: TrickNameToUse } {
   query = query.toLowerCase();
   const technicalName = trick.technicalName.toLowerCase();
   const alias = (trick.alias || '').toLowerCase();
-  return Math.min(textDistance(technicalName, query), textDistance(alias, query));
+
+  const distanceTechnicalName = textDistance(technicalName, query);
+  const distanceAlias = textDistance(alias, query);
+
+  return distanceAlias <= distanceTechnicalName
+    ? { distance: distanceAlias, nameToUse: 'alias' }
+    : { distance: distanceTechnicalName, nameToUse: 'technical' };
 }
 
-function textSearch(tricks: Trick[], query: string): Trick[] {
+function textSearch(tricks: Trick[], query: string): { trick: Trick; nameToUse: TrickNameToUse }[] {
   const MATCH_DISTANCE_MAX = Math.ceil(query.length / 3);
   return tricks
     .map((trick) => {
-      return { trick: trick, score: trickNameDistance(trick, query) };
+      const { distance, nameToUse } = trickNameDistance(trick, query);
+      return {
+        trick: trick,
+        dist: distance,
+        nameToUse: nameToUse,
+      };
     })
-    .filter((trickScorePair) => trickScorePair.score <= MATCH_DISTANCE_MAX)
-    .sort((a, b) => a.score - b.score)
-    .map((trickScorePair) => trickScorePair.trick);
+    .filter((elem) => elem.dist <= MATCH_DISTANCE_MAX)
+    .sort((a, b) => a.dist - b.dist)
+    .map((elem) => {
+      return {
+        trick: elem.trick,
+        nameToUse: elem.nameToUse,
+      };
+    });
 }
 
 function comparePrimaryKey(a: Trick, b: Trick): number {
@@ -108,9 +129,9 @@ function sortTricks(tricks: Trick[], sorting: SortOrder): Trick[] {
   }
 }
 
-function searchItemFromTrick(trick: Trick): SearchItem {
+function searchItemFromTrick(trick: Trick, name: TrickNameToUse): SearchItem {
   return {
-    name: trick.alias ?? trick.technicalName,
+    name: name === 'alias' ? trick.alias ?? trick.technicalName : trick.technicalName,
     primaryKey: [trick.primaryKey[0], trick.primaryKey[1]],
     stickFrequency: trick.stickFrequency,
     isFavorite: trick.isFavourite,
@@ -134,7 +155,7 @@ function groupTricksToSearchResult(
       currentGroup = mapTrickToAttribute(trick, sorting);
       result.push({ title: currentGroup, items: [] });
     }
-    const searchItem = searchItemFromTrick(trick);
+    const searchItem = searchItemFromTrick(trick, 'alias');
     result[result.length - 1].items.push(searchItem);
   }
   return result;
@@ -147,7 +168,9 @@ export function searchInTricks(
 ): SearchResult {
   if (searchParameters.searchText !== undefined && searchParameters.searchText !== '') {
     const matchingTricks = textSearch(allTricks, searchParameters.searchText);
-    const searchItems = matchingTricks.map(searchItemFromTrick);
+    const searchItems = matchingTricks.map((trickWithInfo) =>
+      searchItemFromTrick(trickWithInfo.trick, trickWithInfo.nameToUse)
+    );
     return [
       {
         title: `"${searchParameters.searchText}"`,

--- a/src/services/searchAndFilterTricks.ts
+++ b/src/services/searchAndFilterTricks.ts
@@ -2,6 +2,63 @@ import { Trick } from '@/lib/database/daos/trick';
 import { SearchItem, SearchParameters, SearchResult, SortOrder } from '@/types/search';
 import { isStickableNew } from '@/util/misc';
 
+function equalLengthStringDistance(a: string, b: string): number {
+  if (a.length !== b.length) {
+    throw new Error('Both strings need to be of equal length.');
+  }
+
+  // Here exists the option to swap out the UNEQUAL_CHARACTER_DISTANCE for a
+  // more sophisticated distance between characters (based on the distance
+  // between them on a keyboard for typos, or based on how similar they sound
+  //  for example)
+  const UNEQUAL_CHARACTER_DISTANCE = 1;
+
+  let diff = 0;
+  for (let i = 0; i < a.length; i++) {
+    diff += a.charAt(i) == b.charAt(i) ? 0 : UNEQUAL_CHARACTER_DISTANCE;
+  }
+  return diff;
+}
+
+function textDistance(baseText: string, query: string): number {
+  const PENALTY_PER_MISSING_CHAR = 1;
+
+  let minDist = Infinity;
+  for (let originalStartIdx = 0; originalStartIdx < baseText.length; originalStartIdx++) {
+    const maxCommonLength = Math.min(query.length, baseText.length - originalStartIdx);
+    const cutToLengthBase = baseText.substring(
+      originalStartIdx,
+      originalStartIdx + maxCommonLength
+    );
+    const cutToLengthQuery = query.substring(0, maxCommonLength);
+
+    const dist = equalLengthStringDistance(cutToLengthBase, cutToLengthQuery);
+    const missingCharacterPenalty = PENALTY_PER_MISSING_CHAR * (query.length - maxCommonLength);
+    minDist = Math.min(minDist, dist + missingCharacterPenalty);
+  }
+
+  const unmatchedCharactersPenalty = 1 - 1 / (Math.abs(baseText.length - query.length) + 1);
+  return minDist + unmatchedCharactersPenalty;
+}
+
+function trickNameDistance(trick: Trick, query: string): number {
+  query = query.toLowerCase();
+  const technicalName = trick.technicalName.toLowerCase();
+  const alias = (trick.alias || '').toLowerCase();
+  return Math.min(textDistance(technicalName, query), textDistance(alias, query));
+}
+
+function textSearch(tricks: Trick[], query: string): Trick[] {
+  const MATCH_DISTANCE_MAX = Math.ceil(query.length / 3);
+  return tricks
+    .map((trick) => {
+      return { trick: trick, score: trickNameDistance(trick, query) };
+    })
+    .filter((trickScorePair) => trickScorePair.score <= MATCH_DISTANCE_MAX)
+    .sort((a, b) => a.score - b.score)
+    .map((trickScorePair) => trickScorePair.trick);
+}
+
 function comparePrimaryKey(a: Trick, b: Trick): number {
   const statusOrder = ['official', 'userDefined', 'archived'];
   const statusDiff = statusOrder.indexOf(a.primaryKey[1]) - statusOrder.indexOf(b.primaryKey[1]);
@@ -88,15 +145,21 @@ export function searchInTricks(
   searchParameters: SearchParameters,
   mapTrickToAttribute: (t: Trick, sort: SortOrder) => string
 ): SearchResult {
+  if (searchParameters.searchText !== undefined && searchParameters.searchText !== '') {
+    const matchingTricks = textSearch(allTricks, searchParameters.searchText);
+    const searchItems = matchingTricks.map(searchItemFromTrick);
+    return [
+      {
+        title: `"${searchParameters.searchText}"`,
+        items: searchItems,
+      },
+    ];
+  }
+
   const filteredTricks = allTricks.filter((trick) =>
     searchParameters.includedStatuses.includes(trick.primaryKey[1])
   );
 
   const sortedTricks = sortTricks(filteredTricks, searchParameters.sortOrder);
-  const searchResult = groupTricksToSearchResult(
-    sortedTricks,
-    searchParameters.sortOrder,
-    mapTrickToAttribute
-  );
-  return searchResult;
+  return groupTricksToSearchResult(sortedTricks, searchParameters.sortOrder, mapTrickToAttribute);
 }


### PR DESCRIPTION
Addresses #281

# Features
- A search bar is displayed at the top of the trick list (this was already present before this PR, just adding it for completeness)
- When text is input into the search bar a small "x" is displayed at the end of the search bar and all other search features are disabled and visually muted
- The input text can be reset by clicking on the small "x"
- Immediately on inputting text, only search results from the text based search are being shown (sorting, other filters, etc. are disregarded)
- Once no text is in the input field anymore the list returns back to the normal filters (/ sortings / ...). This is also conveyed visually to the user
- The search function is fairly primitive on an algorithmic level but it should work fine for now. Also more loaded in official tricks will be needed to properly test the search function in a real scenario. But fixes should be fairly simple as the whole search logic is implemented behind a single function (`textSearch` in `/src/services/searchAndFilterTricks.ts`)
- The displayed name (alias or technical name) is chosen to reflect the one matching best with the search query

# Missing from the requirements of #281 
The search bar is not always displayed at the top and also does not appear the moment the user starts scrolling upwards. For now it simply lives at the top of the trick list. We can address this at some other point, the feature is not critical right now.

# Screenshot
![Screen Shot 2025-01-28 at 18 04 55](https://github.com/user-attachments/assets/c4e6e91c-2ef2-4037-99ee-b5cee65859f1)

