### PR TITLE
refactor: file structure of i18n folder

### DIFF
--- a/src/i18n/error.ts
+++ b/src/i18n/error.ts
@@ -1,9 +1,0 @@
-import en from './error/error.en.json';
-import es from './error/error.es.json';
-import fr from './error/error.fr.json';
-
-export default {
-  en,
-  es,
-  fr,
-};

--- a/src/i18n/error/index.ts
+++ b/src/i18n/error/index.ts
@@ -1,0 +1,9 @@
+import en from './error.en.json';
+import es from './error.es.json';
+import fr from './error.fr.json';
+
+export default {
+  en,
+  es,
+  fr,
+};

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -1,9 +1,0 @@
-import en from './index/index.en.json';
-import es from './index/index.es.json';
-import fr from './index/index.fr.json';
-
-export default {
-  en,
-  es,
-  fr,
-};

--- a/src/i18n/index/index.en.json
+++ b/src/i18n/index/index.en.json
@@ -1,3 +1,0 @@
-{
-  "greeting": "Hello World!"
-}

--- a/src/i18n/index/index.es.json
+++ b/src/i18n/index/index.es.json
@@ -1,3 +1,0 @@
-{
-  "greeting": "Hola mundo!"
-}

--- a/src/i18n/index/index.fr.json
+++ b/src/i18n/index/index.fr.json
@@ -1,3 +1,0 @@
-{
-  "greeting": "Salut tout le monde!"
-}

--- a/src/i18n/navbar.ts
+++ b/src/i18n/navbar.ts
@@ -1,9 +1,0 @@
-import en from './navbar/navbar.en.json';
-import fr from './navbar/navbar.fr.json';
-import es from './navbar/navbar.es.json';
-
-export default {
-  en,
-  fr,
-  es,
-};

--- a/src/i18n/navbar/index.ts
+++ b/src/i18n/navbar/index.ts
@@ -1,0 +1,5 @@
+import en from './navbar.en.json';
+import fr from './navbar.fr.json';
+import es from './navbar.es.json';
+
+export default { en, fr, es };

--- a/src/i18n/notFound.ts
+++ b/src/i18n/notFound.ts
@@ -1,9 +1,0 @@
-import en from './notFound/notFound.en.json';
-import es from './notFound/notFound.es.json';
-import fr from './notFound/notFound.fr.json';
-
-export default {
-  en,
-  es,
-  fr,
-};

--- a/src/i18n/notFound/index.ts
+++ b/src/i18n/notFound/index.ts
@@ -1,0 +1,5 @@
+import en from './notFound.en.json';
+import es from './notFound.es.json';
+import fr from './notFound.fr.json';
+
+export default { en, es, fr };

--- a/src/i18n/settings.ts
+++ b/src/i18n/settings.ts
@@ -1,9 +1,0 @@
-import en from './settings/settings.en.json';
-import es from './settings/settings.es.json';
-import fr from './settings/settings.fr.json';
-
-export default {
-  en,
-  es,
-  fr,
-};

--- a/src/i18n/settings/index.ts
+++ b/src/i18n/settings/index.ts
@@ -1,0 +1,5 @@
+import en from './settings.en.json';
+import es from './settings.es.json';
+import fr from './settings.fr.json';
+
+export default { en, es, fr };

--- a/src/i18n/video.ts
+++ b/src/i18n/video.ts
@@ -1,9 +1,0 @@
-import en from './video/video.en.json';
-import es from './video/video.es.json';
-import fr from './video/video.fr.json';
-
-export default {
-  en,
-  es,
-  fr,
-};

--- a/src/i18n/video/index.ts
+++ b/src/i18n/video/index.ts
@@ -1,0 +1,5 @@
+import en from './video.en.json';
+import es from './video.es.json';
+import fr from './video.fr.json';
+
+export default { en, es, fr };

--- a/src/routes/tricks/NewTrickRoute.vue
+++ b/src/routes/tricks/NewTrickRoute.vue
@@ -12,7 +12,7 @@ import Section from '@/components/ui/section/Section.vue';
 import { useI18n } from 'vue-i18n';
 import messages from '@/i18n/tricks/new/index';
 import messages_positions from '@/i18n/common/positions';
-import messages_errors from '@/i18n/error.ts';
+import messages_errors from '@/i18n/error';
 import { i18nMerge } from '@/i18n/i18nmerge';
 import { DbPositionZod } from '@/lib/database/schemas/CurrentVersionSchema';
 import PositionSelectInput from '@/components/ui/customForm/PositionSelectInput.vue';


### PR DESCRIPTION
Some translations still used the old / improper structure of
```
/ i18n
        /myTranslation
                myTranslation.en.json
                myTranslation.es.json
                ...
        myTranslation.ts
```

while some where utilizing the more new / more correct structure of
```
/ i18n
        /myTranslation
                index.ts
                myTranslation.en.json
                myTranslation.es.json
                ...
```

All i18n folders were restructured to the second form. This should have no functional effect on the code.