### PR TITLE
feat: show favorites at top of trick list

### DIFF
--- a/src/components/stickable/list/TrickSearchMenu.vue
+++ b/src/components/stickable/list/TrickSearchMenu.vue
@@ -219,15 +219,25 @@ function highlightFilterClasses(highlight: boolean | undefined): string {
             size="sm"
             :class="highlightFilterClasses(searchParameters?.showFavoritesAtTop)"
           >
-            Favorites: {{ searchParameters?.showFavoritesAtTop ? 'Top' : 'Regular' }}
+            {{
+              t(
+                searchParameters?.showFavoritesAtTop
+                  ? 'favoritesPlacement.triggerTitleTop'
+                  : 'favoritesPlacement.triggerTitleRegular'
+              )
+            }}
           </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent>
-          <DropdownMenuLabel> Favorites position </DropdownMenuLabel>
+          <DropdownMenuLabel> {{ t('favoritesPlacement.menuLabel') }} </DropdownMenuLabel>
           <DropdownMenuSeparator />
           <DropdownMenuRadioGroup v-model="favoritesTreatment">
-            <DropdownMenuRadioItem value="showAtTop"> Top </DropdownMenuRadioItem>
-            <DropdownMenuRadioItem value="dontShowAtTop"> Regular place </DropdownMenuRadioItem>
+            <DropdownMenuRadioItem value="showAtTop">
+              {{ t('favoritesPlacement.radioItems.top') }}
+            </DropdownMenuRadioItem>
+            <DropdownMenuRadioItem value="dontShowAtTop">
+              {{ t('favoritesPlacement.radioItems.regular') }}
+            </DropdownMenuRadioItem>
           </DropdownMenuRadioGroup>
         </DropdownMenuContent>
       </DropdownMenu>

--- a/src/components/stickable/list/TrickSearchMenu.vue
+++ b/src/components/stickable/list/TrickSearchMenu.vue
@@ -22,6 +22,10 @@ import { i18nMerge } from '@/i18n/i18nmerge';
 import messages from '@/i18n/searchMenu';
 import messagesStickableStatus from '@/i18n/common/stickableStatus';
 import { Icon } from '@iconify/vue/dist/iconify.js';
+import DropdownMenuRadioGroup from '@/components/ui/dropdown-menu/DropdownMenuRadioGroup.vue';
+import DropdownMenuRadioItem from '@/components/ui/dropdown-menu/DropdownMenuRadioItem.vue';
+import DropdownMenuLabel from '@/components/ui/dropdown-menu/DropdownMenuLabel.vue';
+import DropdownMenuSeparator from '@/components/ui/dropdown-menu/DropdownMenuSeparator.vue';
 
 const { t } = useI18n({
   messages: i18nMerge(messages, messagesStickableStatus),
@@ -62,7 +66,7 @@ const sortingOptions: { titleKey: string; directionTitleKey?: string; value: Sor
 ];
 const activeSortingOption = ref<SortOrder>(searchParameters.value?.sortOrder);
 
-watchEffect(async () => {
+watchEffect(() => {
   if (searchParameters.value === undefined) {
     throw new Error('Search Parameters model needs to be passed to TrickSearchMenu!');
   }
@@ -108,6 +112,20 @@ function setSearchText(text: string | number) {
 
 const textSearchContainsText = computed<boolean>(() => {
   return searchParameters.value !== undefined && !!searchParameters.value.searchText;
+});
+
+// FAVORITES
+
+type FavoritesAtTopOptions = 'showAtTop' | 'dontShowAtTop';
+const favoritesTreatment = ref<FavoritesAtTopOptions>(
+  searchParameters.value.showFavoritesAtTop ? 'showAtTop' : 'dontShowAtTop'
+);
+watchEffect(() => {
+  if (!searchParameters.value) {
+    throw new Error('Search Parameters model needs to be passed to TrickSearchMenu!');
+  }
+  searchParameters.value.showFavoritesAtTop = favoritesTreatment.value === 'showAtTop';
+  console.log(favoritesTreatment.value);
 });
 </script>
 
@@ -156,7 +174,7 @@ const textSearchContainsText = computed<boolean>(() => {
       </div>
     </div>
 
-    <div class="flex flex-row gap-1 w-full">
+    <div class="flex flex-row flex-wrap gap-1 w-full">
       <DropdownMenu>
         <DropdownMenuTrigger as-child :disabled="textSearchContainsText">
           <Button :variant="includedStatusesTriggerVariant" size="sm">
@@ -182,6 +200,22 @@ const textSearchContainsText = computed<boolean>(() => {
           >
             {{ t('archived') }}
           </DropdownMenuCheckboxItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      <DropdownMenu>
+        <DropdownMenuTrigger as-child :disabled="textSearchContainsText">
+          <Button variant="secondary" size="sm">
+            Favorites: {{ searchParameters?.showFavoritesAtTop ? 'Top' : 'Regular' }}
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent>
+          <DropdownMenuLabel> Favorites position </DropdownMenuLabel>
+          <DropdownMenuSeparator />
+          <DropdownMenuRadioGroup v-model="favoritesTreatment">
+            <DropdownMenuRadioItem value="showAtTop"> Top </DropdownMenuRadioItem>
+            <DropdownMenuRadioItem value="dontShowAtTop"> Regular place </DropdownMenuRadioItem>
+          </DropdownMenuRadioGroup>
         </DropdownMenuContent>
       </DropdownMenu>
     </div>

--- a/src/components/stickable/list/TrickSearchMenu.vue
+++ b/src/components/stickable/list/TrickSearchMenu.vue
@@ -88,13 +88,14 @@ function updateIncludedStatuses(status: StickableStatus) {
   searchParameters.value?.includedStatuses.push(status);
 }
 
-const includedStatusesTriggerVariant = computed(() => {
-  const allOptionsChecked =
-    searchParameters.value?.includedStatuses.includes('official') &&
-    searchParameters.value?.includedStatuses.includes('userDefined') &&
-    searchParameters.value?.includedStatuses.includes('archived');
-  return allOptionsChecked ? 'secondary' : 'default';
-});
+const shouldStatusBeHighlighted = computed(
+  () =>
+    !(
+      searchParameters.value?.includedStatuses.includes('official') &&
+      searchParameters.value?.includedStatuses.includes('userDefined') &&
+      searchParameters.value?.includedStatuses.includes('archived')
+    )
+);
 
 // TEXT SEARCH
 
@@ -125,8 +126,12 @@ watchEffect(() => {
     throw new Error('Search Parameters model needs to be passed to TrickSearchMenu!');
   }
   searchParameters.value.showFavoritesAtTop = favoritesTreatment.value === 'showAtTop';
-  console.log(favoritesTreatment.value);
 });
+
+// GENERAL
+function highlightFilterClasses(highlight: boolean | undefined): string {
+  return highlight ? 'font-medium' : 'font-normal';
+}
 </script>
 
 <template>
@@ -177,7 +182,11 @@ watchEffect(() => {
     <div class="flex flex-row flex-wrap gap-1 w-full">
       <DropdownMenu>
         <DropdownMenuTrigger as-child :disabled="textSearchContainsText">
-          <Button :variant="includedStatusesTriggerVariant" size="sm">
+          <Button
+            variant="secondary"
+            size="sm"
+            :class="highlightFilterClasses(shouldStatusBeHighlighted)"
+          >
             {{ t('includedStickableStatuses.triggerTitle') }}
           </Button>
         </DropdownMenuTrigger>
@@ -205,7 +214,11 @@ watchEffect(() => {
 
       <DropdownMenu>
         <DropdownMenuTrigger as-child :disabled="textSearchContainsText">
-          <Button variant="secondary" size="sm">
+          <Button
+            variant="secondary"
+            size="sm"
+            :class="highlightFilterClasses(searchParameters?.showFavoritesAtTop)"
+          >
             Favorites: {{ searchParameters?.showFavoritesAtTop ? 'Top' : 'Regular' }}
           </Button>
         </DropdownMenuTrigger>

--- a/src/i18n/list/list.en.json
+++ b/src/i18n/list/list.en.json
@@ -2,7 +2,8 @@
   "sectionTitles": {
     "difficulty": "Difficulty {difficulty}",
     "unknown": "Unknown",
-    "notDetermined": "Not determined"
+    "notDetermined": "Not determined",
+    "favorites": "Favorites"
   },
   "cards": {
     "badges": {

--- a/src/i18n/list/list.es.json
+++ b/src/i18n/list/list.es.json
@@ -2,7 +2,8 @@
   "sectionTitles": {
     "difficulty": "Dificultad {difficulty}",
     "unknown": "Desconocido",
-    "notDetermined": "No determinado"
+    "notDetermined": "No determinado",
+    "favorites": "Favoritos"
   },
   "cards": {
     "badges": {

--- a/src/i18n/list/list.fr.json
+++ b/src/i18n/list/list.fr.json
@@ -2,7 +2,8 @@
   "sectionTitles": {
     "difficulty": "Difficulté {difficulty}",
     "unknown": "Inconnu",
-    "notDetermined": "Non déterminé"
+    "notDetermined": "Non déterminé",
+    "favorites": "Favoris"
   },
   "cards": {
     "badges": {

--- a/src/i18n/searchMenu/searchMenu.en.json
+++ b/src/i18n/searchMenu/searchMenu.en.json
@@ -11,5 +11,14 @@
   },
   "includedStickableStatuses": {
     "triggerTitle": "Status"
+  },
+  "favoritesPlacement": {
+    "triggerTitleTop": "Favorites: Top",
+    "triggerTitleRegular": "Favorites: Regular",
+    "menuLabel": "Favorites position",
+    "radioItems": {
+      "top": "Top",
+      "regular": "Regular"
+    }
   }
 }

--- a/src/i18n/searchMenu/searchMenu.es.json
+++ b/src/i18n/searchMenu/searchMenu.es.json
@@ -11,5 +11,14 @@
   },
   "includedStickableStatuses": {
     "triggerTitle": "Estado"
+  },
+  "favoritesPlacement": {
+    "triggerTitleTop": "Favoritos: Top",
+    "triggerTitleRegular": "Favoritos: Regular",
+    "menuLabel": "Posición de favoritos",
+    "radioItems": {
+      "top": "Top",
+      "regular": "Regular"
+    }
   }
 }

--- a/src/i18n/searchMenu/searchMenu.fr.json
+++ b/src/i18n/searchMenu/searchMenu.fr.json
@@ -11,5 +11,14 @@
   },
   "includedStickableStatuses": {
     "triggerTitle": "Statut"
+  },
+  "favoritesPlacement": {
+    "triggerTitleTop": "Favoris : Top",
+    "triggerTitleRegular": "Favoris : Régulier",
+    "menuLabel": "Position des favoris",
+    "radioItems": {
+      "top": "Top",
+      "regular": "Régulier"
+    }
   }
 }

--- a/src/routes/tricks/TrickList.vue
+++ b/src/routes/tricks/TrickList.vue
@@ -27,6 +27,7 @@ const LOCAL_STORAGE_PARAMETERS_KEY: string = 'SearchParameters-Tricks';
 const DEFAULT_SEARCH_PARAMETERS: SearchParameters = {
   sortOrder: 'difficulty-asc',
   includedStatuses: ['official', 'userDefined', 'archived'],
+  showFavoritesAtTop: true,
 };
 
 function loadSearchParameters(): SearchParameters {
@@ -39,6 +40,8 @@ function loadSearchParameters(): SearchParameters {
   parameters.sortOrder = parameters.sortOrder || DEFAULT_SEARCH_PARAMETERS.sortOrder;
   parameters.includedStatuses =
     parameters.includedStatuses || DEFAULT_SEARCH_PARAMETERS.includedStatuses;
+  parameters.showFavoritesAtTop =
+    parameters.showFavoritesAtTop || DEFAULT_SEARCH_PARAMETERS.showFavoritesAtTop;
 
   return parameters;
 }

--- a/src/routes/tricks/TrickList.vue
+++ b/src/routes/tricks/TrickList.vue
@@ -75,7 +75,12 @@ watch(
   [searchParameters, i18n.locale],
   async () => {
     const allTricks = await tricksDao.getAll();
-    searchResult.value = searchInTricks(allTricks, searchParameters.value, trickToAttribute);
+    searchResult.value = searchInTricks(
+      allTricks,
+      searchParameters.value,
+      trickToAttribute,
+      t('sectionTitles.favorites')
+    );
     storeSearchParameters(searchParameters.value);
   },
   { immediate: true, deep: true }

--- a/src/services/searchAndFilterTricks.ts
+++ b/src/services/searchAndFilterTricks.ts
@@ -170,7 +170,8 @@ function groupTricksToSearchResult(
 export function searchInTricks(
   allTricks: Trick[],
   searchParameters: SearchParameters,
-  mapTrickToAttribute: (t: Trick, sort: SortOrder) => string
+  mapTrickToAttribute: (t: Trick, sort: SortOrder) => string,
+  favoritesSectionTitle: string
 ): SearchResult {
   if (searchParameters.searchText !== undefined && searchParameters.searchText !== '') {
     const matchingTricks = textSearch(allTricks, searchParameters.searchText);
@@ -203,7 +204,7 @@ export function searchInTricks(
 
   const sortedTricksWithoutFavorites = sortedTricks.filter((trick) => !trick.isFavourite);
   const favoritesSearchItem: SearchSection = {
-    title: 'Favorites',
+    title: favoritesSectionTitle,
     items: isolatedFavorites.map((trick) => searchItemFromTrick(trick, 'alias')),
   };
   const searchResultWithoutFavorites = groupTricksToSearchResult(

--- a/src/services/searchAndFilterTricks.ts
+++ b/src/services/searchAndFilterTricks.ts
@@ -196,6 +196,11 @@ export function searchInTricks(
   }
 
   const isolatedFavorites = sortedTricks.filter((trick) => trick.isFavourite);
+
+  if (isolatedFavorites.length == 0) {
+    return groupTricksToSearchResult(sortedTricks, searchParameters.sortOrder, mapTrickToAttribute);
+  }
+
   const sortedTricksWithoutFavorites = sortedTricks.filter((trick) => !trick.isFavourite);
   const favoritesSearchItem: SearchSection = {
     title: 'Favorites',

--- a/src/services/searchAndFilterTricks.ts
+++ b/src/services/searchAndFilterTricks.ts
@@ -1,5 +1,11 @@
 import { Trick } from '@/lib/database/daos/trick';
-import { SearchItem, SearchParameters, SearchResult, SortOrder } from '@/types/search';
+import {
+  SearchItem,
+  SearchParameters,
+  SearchResult,
+  SearchSection,
+  SortOrder,
+} from '@/types/search';
 import { isStickableNew } from '@/util/misc';
 
 type TrickNameToUse = 'alias' | 'technical';
@@ -184,5 +190,21 @@ export function searchInTricks(
   );
 
   const sortedTricks = sortTricks(filteredTricks, searchParameters.sortOrder);
-  return groupTricksToSearchResult(sortedTricks, searchParameters.sortOrder, mapTrickToAttribute);
+
+  if (!searchParameters.showFavoritesAtTop) {
+    return groupTricksToSearchResult(sortedTricks, searchParameters.sortOrder, mapTrickToAttribute);
+  }
+
+  const isolatedFavorites = sortedTricks.filter((trick) => trick.isFavourite);
+  const sortedTricksWithoutFavorites = sortedTricks.filter((trick) => !trick.isFavourite);
+  const favoritesSearchItem: SearchSection = {
+    title: 'Favorites',
+    items: isolatedFavorites.map((trick) => searchItemFromTrick(trick, 'alias')),
+  };
+  const searchResultWithoutFavorites = groupTricksToSearchResult(
+    sortedTricksWithoutFavorites,
+    searchParameters.sortOrder,
+    mapTrickToAttribute
+  );
+  return [favoritesSearchItem].concat(searchResultWithoutFavorites);
 }

--- a/src/types/search.ts
+++ b/src/types/search.ts
@@ -27,4 +27,5 @@ export type SearchParameters = {
   searchText?: string;
   sortOrder: SortOrder;
   includedStatuses: StickableStatus[];
+  showFavoritesAtTop: boolean;
 };


### PR DESCRIPTION
Addresses #295 

# Features
- Add filtering option allowing the user between showing their favorite tricks on the top of the list or within it like all other tricks
- Depending on the option chosen, show the users tricks at the top of the list
- Highlight the dropdown trigger if the option, showing the favorites at the top, is chosen to indicate that a form of special sorting is applied

# Side effect
- The highlighting of the "Status" options was updated to align the style of both the favorites and the status trigger buttons

# Screenshot
![Screen Shot 2025-01-31 at 19 15 49](https://github.com/user-attachments/assets/4283aadc-8591-4a3c-9418-20b84409c732)
