### PR TITLE
feat: select alias or technical name

### DIFF
--- a/src/components/stickable/list/TrickSearchMenu.vue
+++ b/src/components/stickable/list/TrickSearchMenu.vue
@@ -10,7 +10,7 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import { Input } from '@/components/ui/input';
-import { SearchParameters, SortOrder } from '@/types/search';
+import { SearchParameters, SortOrder, TrickNameOption } from '@/types/search';
 import DropdownMenu from '@/components/ui/dropdown-menu/DropdownMenu.vue';
 import DropdownMenuTrigger from '@/components/ui/dropdown-menu/DropdownMenuTrigger.vue';
 import DropdownMenuContent from '@/components/ui/dropdown-menu/DropdownMenuContent.vue';
@@ -128,7 +128,18 @@ watchEffect(() => {
   searchParameters.value.showFavoritesAtTop = favoritesTreatment.value === 'showAtTop';
 });
 
+// NAME
+
+const preferredName = ref<TrickNameOption>(searchParameters.value.preferredName);
+watchEffect(() => {
+  if (!searchParameters.value) {
+    throw new Error('Search Parameters model needs to be passed to TrickSearchMenu!');
+  }
+  searchParameters.value.preferredName = preferredName.value;
+});
+
 // GENERAL
+
 function highlightFilterClasses(highlight: boolean | undefined): string {
   return highlight ? 'font-medium' : 'font-normal';
 }
@@ -237,6 +248,34 @@ function highlightFilterClasses(highlight: boolean | undefined): string {
             </DropdownMenuRadioItem>
             <DropdownMenuRadioItem value="dontShowAtTop">
               {{ t('favoritesPlacement.radioItems.regular') }}
+            </DropdownMenuRadioItem>
+          </DropdownMenuRadioGroup>
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      <DropdownMenu>
+        <DropdownMenuTrigger as-child :disabled="textSearchContainsText">
+          <Button
+            variant="secondary"
+            size="sm"
+            :class="highlightFilterClasses(searchParameters?.preferredName == 'technicalName')"
+          >
+            {{
+              t(
+                searchParameters?.preferredName == 'alias'
+                  ? 'preferredName.triggerTitleAlias'
+                  : 'preferredName.triggerTitleTechnicalName'
+              )
+            }}
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent>
+          <DropdownMenuRadioGroup v-model="preferredName">
+            <DropdownMenuRadioItem value="alias">
+              {{ t('preferredName.radioItems.alias') }}
+            </DropdownMenuRadioItem>
+            <DropdownMenuRadioItem value="technicalName">
+              {{ t('preferredName.radioItems.technicalName') }}
             </DropdownMenuRadioItem>
           </DropdownMenuRadioGroup>
         </DropdownMenuContent>

--- a/src/i18n/searchMenu/searchMenu.en.json
+++ b/src/i18n/searchMenu/searchMenu.en.json
@@ -20,5 +20,13 @@
       "top": "Top",
       "regular": "Regular"
     }
+  },
+  "preferredName": {
+    "triggerTitleAlias": "Name: Alias",
+    "triggerTitleTechnicalName": "Name: Technical",
+    "radioItems": {
+      "alias": "Alias (if possible)",
+      "technicalName": "Technical Name"
+    }
   }
 }

--- a/src/i18n/searchMenu/searchMenu.es.json
+++ b/src/i18n/searchMenu/searchMenu.es.json
@@ -20,5 +20,13 @@
       "top": "Top",
       "regular": "Regular"
     }
+  },
+  "preferredName": {
+    "triggerTitleAlias": "Nombre: Alias",
+    "triggerTitleTechnicalName": "Nombre: Técnico",
+    "radioItems": {
+      "alias": "Alias (si es posible)",
+      "technicalName": "Nombre técnico"
+    }
   }
 }

--- a/src/i18n/searchMenu/searchMenu.fr.json
+++ b/src/i18n/searchMenu/searchMenu.fr.json
@@ -20,5 +20,13 @@
       "top": "Top",
       "regular": "Régulier"
     }
+  },
+  "preferredName": {
+    "triggerTitleAlias": "Nom : Alias",
+    "triggerTitleTechnicalName": "Nom : Technique",
+    "radioItems": {
+      "alias": "Alias (si possible)",
+      "technicalName": "Nom technique"
+    }
   }
 }

--- a/src/routes/tricks/TrickList.vue
+++ b/src/routes/tricks/TrickList.vue
@@ -28,6 +28,7 @@ const DEFAULT_SEARCH_PARAMETERS: SearchParameters = {
   sortOrder: 'difficulty-asc',
   includedStatuses: ['official', 'userDefined', 'archived'],
   showFavoritesAtTop: true,
+  preferredName: 'alias',
 };
 
 function loadSearchParameters(): SearchParameters {
@@ -42,6 +43,7 @@ function loadSearchParameters(): SearchParameters {
     parameters.includedStatuses || DEFAULT_SEARCH_PARAMETERS.includedStatuses;
   parameters.showFavoritesAtTop =
     parameters.showFavoritesAtTop || DEFAULT_SEARCH_PARAMETERS.showFavoritesAtTop;
+  parameters.preferredName = parameters.preferredName || DEFAULT_SEARCH_PARAMETERS.preferredName;
 
   return parameters;
 }

--- a/src/types/search.ts
+++ b/src/types/search.ts
@@ -23,9 +23,12 @@ export type SortOrder =
   | 'yearEstablished-asc'
   | 'yearEstablished-desc';
 
+export type TrickNameOption = 'alias' | 'technicalName';
+
 export type SearchParameters = {
   searchText?: string;
   sortOrder: SortOrder;
   includedStatuses: StickableStatus[];
   showFavoritesAtTop: boolean;
+  preferredName: TrickNameOption;
 };


### PR DESCRIPTION
Addresses #359

# Features
- Add a dropdown menu for the user to select whether to see the alias names or the technical names
- The selected name is displayed to the user in the trick list. If no alias exists the app falls back to the technical name
- If the option for technical name is selected, the dropdown trigger is highlighted to let the user know that this option causes results which differ from the default
- Full translation into English, Spanish and French

# Screenshot
![Screen Shot 2025-02-01 at 15 53 55](https://github.com/user-attachments/assets/25e55cab-0e00-49ba-8797-7ecbf000d8d1)
