### PR TITLE
feat: new trick page info alert

### DIFF
--- a/components.json
+++ b/components.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://shadcn-vue.com/schema.json",
   "style": "default",
   "typescript": true,
   "tailwind": {
@@ -10,6 +11,9 @@
   "framework": "vite",
   "aliases": {
     "components": "@/components",
-    "utils": "@/lib/utils"
+    "ui": "@/components/ui",
+    "utils": "@/lib/utils",
+    "lib": "@/lib",
+    "composables": "@/composables"
   }
 }

--- a/src/components/ui/alert/Alert.vue
+++ b/src/components/ui/alert/Alert.vue
@@ -1,0 +1,16 @@
+<script setup lang="ts">
+import type { HTMLAttributes } from 'vue';
+import { cn } from '@/lib/utils';
+import { type AlertVariants, alertVariants } from '.';
+
+const props = defineProps<{
+  class?: HTMLAttributes['class'];
+  variant?: AlertVariants['variant'];
+}>();
+</script>
+
+<template>
+  <div :class="cn(alertVariants({ variant }), props.class)" role="alert">
+    <slot />
+  </div>
+</template>

--- a/src/components/ui/alert/AlertDescription.vue
+++ b/src/components/ui/alert/AlertDescription.vue
@@ -1,0 +1,14 @@
+<script setup lang="ts">
+import type { HTMLAttributes } from 'vue';
+import { cn } from '@/lib/utils';
+
+const props = defineProps<{
+  class?: HTMLAttributes['class'];
+}>();
+</script>
+
+<template>
+  <div :class="cn('text-sm [&_p]:leading-relaxed', props.class)">
+    <slot />
+  </div>
+</template>

--- a/src/components/ui/alert/AlertTitle.vue
+++ b/src/components/ui/alert/AlertTitle.vue
@@ -1,0 +1,14 @@
+<script setup lang="ts">
+import type { HTMLAttributes } from 'vue';
+import { cn } from '@/lib/utils';
+
+const props = defineProps<{
+  class?: HTMLAttributes['class'];
+}>();
+</script>
+
+<template>
+  <h5 :class="cn('mb-1 font-medium leading-none tracking-tight', props.class)">
+    <slot />
+  </h5>
+</template>

--- a/src/components/ui/alert/index.ts
+++ b/src/components/ui/alert/index.ts
@@ -1,0 +1,23 @@
+import { cva, type VariantProps } from 'class-variance-authority';
+
+export { default as Alert } from './Alert.vue';
+export { default as AlertDescription } from './AlertDescription.vue';
+export { default as AlertTitle } from './AlertTitle.vue';
+
+export const alertVariants = cva(
+  'relative w-full rounded-lg border p-4 [&>svg~*]:pl-7 [&>svg+div]:translate-y-[-3px] [&>svg]:absolute [&>svg]:left-4 [&>svg]:top-4 [&>svg]:text-foreground',
+  {
+    variants: {
+      variant: {
+        default: 'bg-background text-foreground',
+        destructive:
+          'border-destructive/50 text-destructive dark:border-destructive [&>svg]:text-destructive',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+    },
+  }
+);
+
+export type AlertVariants = VariantProps<typeof alertVariants>;

--- a/src/i18n/tricks/new/tricksNew.en.json
+++ b/src/i18n/tricks/new/tricksNew.en.json
@@ -1,5 +1,10 @@
 {
-  "titleHeading": "Create a new trick",
+  "titleHeading": "Create new personal trick",
+
+  "personalTrickInfo": {
+    "title": "Visible to you only",
+    "description": "This is a personal trick and will be stored only on your device. It will not be shared."
+  },
 
   "label": {
     "technicalName": "Technical Name",

--- a/src/i18n/tricks/new/tricksNew.es.json
+++ b/src/i18n/tricks/new/tricksNew.es.json
@@ -1,6 +1,11 @@
 {
   "titleHeading": "Crear un nuevo truco",
 
+  "personalTrickInfo": {
+    "title": "Visible sólo para usted",
+    "description": "Se trata de un truco personal y se almacenará únicamente en tu dispositivo. No se compartirá."
+  },
+
   "label": {
     "technicalName": "Nombre técnico",
     "alias": "Alias",

--- a/src/i18n/tricks/new/tricksNew.fr.json
+++ b/src/i18n/tricks/new/tricksNew.fr.json
@@ -1,6 +1,11 @@
 {
   "titleHeading": "Créer un nouveau trick",
 
+  "personalTrickInfo": {
+    "title": "Visible uniquement par vous",
+    "description": "Il s'agit d'une information personnelle qui ne sera stockée que sur votre appareil. Il ne sera pas partagé."
+  },
+
   "label": {
     "technicalName": "Nom technique",
     "alias": "Alias",

--- a/src/routes/tricks/NewTrickRoute.vue
+++ b/src/routes/tricks/NewTrickRoute.vue
@@ -21,6 +21,8 @@ import MultilineTextInput from '@/components/ui/customForm/MultilineTextInput.vu
 import TrickSelect from '@/components/ui/customForm/TrickSelect.vue';
 import { ToastAction, useToast } from '@/components/ui/toast';
 import TextInput from '@/components/ui/customForm/TextInput.vue';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { Icon } from '@iconify/vue/dist/iconify.js';
 
 const toast = useToast();
 const router = useRouter();
@@ -135,7 +137,13 @@ function hasHistory(): boolean {
 <template>
   <DefaultLayout>
     <Section>
-      <h1 class="text-2xl md:text-3xl my-4 font-black">{{ t('titleHeading') }}</h1>
+      <h1 class="text-2xl md:text-3xl mb-3 mt-2">{{ t('titleHeading') }}</h1>
+
+      <Alert variant="default" class="my-3">
+        <Icon icon="ic:outline-info" class="w-5 h-5" />
+        <AlertTitle class="pl-3">{{ t('personalTrickInfo.title') }}</AlertTitle>
+        <AlertDescription class="pl-3">{{ t('personalTrickInfo.description') }}</AlertDescription>
+      </Alert>
 
       <form class="grid gap-4 lg:gap-6 grid-cols-4" @submit="submit">
         <TextInput


### PR DESCRIPTION
Addresses #364 

# Description
Added a banner on the trick creation page to inform the user that the trick will be a personal one and visible only to the user themself. This was suggested by @bastislack as he was asked many times what creating a trick like this actually did.

# Screenshot
![Screen Shot 2025-03-03 at 21 58 45](https://github.com/user-attachments/assets/281bb9c9-94f9-4469-9abe-29feadda308e)
