### PR TITLE
Fixed validations for number input

### DIFF
--- a/src/components/ui/customForm/TextInput.vue
+++ b/src/components/ui/customForm/TextInput.vue
@@ -10,6 +10,7 @@ import {
   FormLabel,
   FormMessage,
 } from '@/components/ui/form';
+import { InputHTMLAttributes } from 'vue';
 
 const props = defineProps<{
   title: string;
@@ -17,8 +18,8 @@ const props = defineProps<{
   formFieldName: string;
   placeholder?: string;
   class?: string;
-  inputMode?: string;
-  type?: string;
+  inputMode?: InputHTMLAttributes['inputmode'];
+  type?: InputHTMLAttributes['type'];
 }>();
 </script>
 

--- a/src/components/ui/customForm/TextInput.vue
+++ b/src/components/ui/customForm/TextInput.vue
@@ -20,6 +20,8 @@ const props = defineProps<{
   class?: string;
   inputMode?: InputHTMLAttributes['inputmode'];
   type?: InputHTMLAttributes['type'];
+  // This is used to pass values for the message translation interpolation
+  errorValues?: Record<string, string>;
 }>();
 </script>
 
@@ -36,7 +38,7 @@ const props = defineProps<{
       <FormDescription v-if="description">
         {{ description }}
       </FormDescription>
-      <FormMessage />
+      <FormMessage :values="props.errorValues" />
       <FormControl>
         <Input
           :type="type || 'text'"

--- a/src/components/ui/customForm/TextInput.vue
+++ b/src/components/ui/customForm/TextInput.vue
@@ -17,6 +17,8 @@ const props = defineProps<{
   formFieldName: string;
   placeholder?: string;
   class?: string;
+  inputMode?: string;
+  type?: string;
 }>();
 </script>
 
@@ -35,7 +37,12 @@ const props = defineProps<{
       </FormDescription>
       <FormMessage />
       <FormControl>
-        <Input type="text" :placeholder="placeholder" v-bind="componentField" />
+        <Input
+          :type="type || 'text'"
+          :placeholder="placeholder"
+          :inputMode="inputMode"
+          v-bind="componentField"
+        />
       </FormControl>
     </FormItem>
   </FormField>

--- a/src/components/ui/form/FormMessage.vue
+++ b/src/components/ui/form/FormMessage.vue
@@ -1,18 +1,10 @@
 <script lang="ts" setup>
 import { ErrorMessage } from 'vee-validate';
 import { toValue } from 'vue';
-import { useI18n } from 'vue-i18n';
-
-import messagesErrors from '@/i18n/error';
 
 import { useFormField } from './useFormField';
 
 const { name, formMessageId } = useFormField();
-
-const { t } = useI18n({
-  messages: messagesErrors,
-  scope: 'local',
-});
 </script>
 
 <template>
@@ -23,6 +15,6 @@ const { t } = useI18n({
     class="text-sm font-medium text-destructive"
     v-slot="{ message }"
   >
-    {{ message ? t(message) : '' }}
+    {{ message }}
   </ErrorMessage>
 </template>

--- a/src/components/ui/form/FormMessage.vue
+++ b/src/components/ui/form/FormMessage.vue
@@ -1,16 +1,15 @@
 <script lang="ts" setup>
 import { ErrorMessage } from 'vee-validate';
-import { toValue, computed } from 'vue';
+import { toValue } from 'vue';
 import { useI18n } from 'vue-i18n';
 
 import messagesErrors from '@/i18n/error';
-import { i18nMerge } from '@/i18n/i18nmerge';
 
 import { useFormField } from './useFormField';
 
 const { name, formMessageId } = useFormField();
 const { t } = useI18n({
-  messages: i18nMerge(messagesErrors),
+  messages: messagesErrors,
   scope: 'local',
 });
 
@@ -18,14 +17,6 @@ const props = defineProps<{
   // This is used to pass values for the message translation interpolation
   values?: Record<string, string>;
 }>();
-
-// Create a computed function to translate messages
-const translateMessage = computed(() => {
-  return (message: string) => {
-    if (!message) return '';
-    return t(message, props.values || {});
-  };
-});
 </script>
 
 <template>
@@ -36,6 +27,6 @@ const translateMessage = computed(() => {
     class="text-sm font-medium text-destructive"
     v-slot="{ message }"
   >
-    {{ message ? translateMessage(message) : '' }}
+    {{ message ? t(message, props.values || {}) : '' }}
   </ErrorMessage>
 </template>

--- a/src/components/ui/form/FormMessage.vue
+++ b/src/components/ui/form/FormMessage.vue
@@ -1,10 +1,31 @@
 <script lang="ts" setup>
 import { ErrorMessage } from 'vee-validate';
-import { toValue } from 'vue';
+import { toValue, computed } from 'vue';
+import { useI18n } from 'vue-i18n';
+
+import messagesErrors from '@/i18n/error';
+import { i18nMerge } from '@/i18n/i18nmerge';
 
 import { useFormField } from './useFormField';
 
 const { name, formMessageId } = useFormField();
+const { t } = useI18n({
+  messages: i18nMerge(messagesErrors),
+  scope: 'local',
+});
+
+const props = defineProps<{
+  // This is used to pass values for the message translation interpolation
+  values?: Record<string, string>;
+}>();
+
+// Create a computed function to translate messages
+const translateMessage = computed(() => {
+  return (message: string) => {
+    if (!message) return '';
+    return t(message, props.values || {});
+  };
+});
 </script>
 
 <template>
@@ -15,6 +36,6 @@ const { name, formMessageId } = useFormField();
     class="text-sm font-medium text-destructive"
     v-slot="{ message }"
   >
-    {{ message }}
+    {{ message ? translateMessage(message) : '' }}
   </ErrorMessage>
 </template>

--- a/src/i18n/error/error.en.json
+++ b/src/i18n/error/error.en.json
@@ -6,8 +6,8 @@
   "Required": "This is required",
   "INPUT_NOT_NUMBER": "Please enter a number",
   "INPUT_NOT_INTEGER": "Please enter a whole number",
-  "INPUT_NUMBER_BELOW_MIN": "Input must be no less than {value}",
-  "INPUT_NUMBER_ABOVE_MAX": "Input must be no more than {value}",
+  "INPUT_NUMBER_BELOW_MIN": "Input must be no less than {min}",
+  "INPUT_NUMBER_ABOVE_MAX": "Input must be no more than {max}",
   "POSITION_INVALID": "Provided Position is invalid",
   "INPUT_TOO_SHORT": "Input must be at least {limit} characters long",
   "INPUT_TOO_LONG": "Input must be at most {limit} characters long"

--- a/src/i18n/error/error.es.json
+++ b/src/i18n/error/error.es.json
@@ -6,8 +6,8 @@
   "Required": "Esto es necesario",
   "INPUT_NOT_NUMBER": "Introduzca un número",
   "INPUT_NOT_INTEGER": "Introduzca un número entero",
-  "INPUT_NUMBER_BELOW_MIN": "La entrada no debe ser inferior a {value}",
-  "INPUT_NUMBER_ABOVE_MAX": "La entrada no debe ser mayor que {value}",
+  "INPUT_NUMBER_BELOW_MIN": "La entrada no debe ser inferior a {min}",
+  "INPUT_NUMBER_ABOVE_MAX": "La entrada no debe ser mayor que {max}",
   "POSITION_INVALID": "Proporcionado La posición no es válida",
   "INPUT_TOO_SHORT": "La entrada debe tener al menos {limit} caracteres",
   "INPUT_TOO_LONG": "La entrada debe tener como máximo {limit} caracteres"

--- a/src/i18n/error/error.fr.json
+++ b/src/i18n/error/error.fr.json
@@ -6,8 +6,8 @@
   "Required": "Ceci est nécessaire",
   "INPUT_NOT_NUMBER": "Veuillez saisir un numéro",
   "INPUT_NOT_INTEGER": "Veuillez saisir un nombre entier",
-  "INPUT_NUMBER_BELOW_MIN": "L'entrée ne doit pas être inférieure à {value}",
-  "INPUT_NUMBER_ABOVE_MAX": "L'entrée ne doit pas dépasser {value}",
+  "INPUT_NUMBER_BELOW_MIN": "L'entrée ne doit pas être inférieure à {min}",
+  "INPUT_NUMBER_ABOVE_MAX": "L'entrée ne doit pas dépasser {max}",
   "POSITION_INVALID": "Fourni La position n'est pas valide",
   "INPUT_TOO_SHORT": "L'entrée doit comporter au moins {limit} caractères",
   "INPUT_TOO_LONG": "L'entrée doit comporter au maximum {limit} caractères"

--- a/src/i18n/error/error.pt.json
+++ b/src/i18n/error/error.pt.json
@@ -6,8 +6,8 @@
   "INPUT_REQUIRED": "Este campo é obrigatório",
   "INPUT_NOT_NUMBER": "Por favor, insira um número",
   "INPUT_NOT_INTEGER": "Por favor, insira um número inteiro",
-  "INPUT_NUMBER_BELOW_MIN": "A entrada não deve ser menor que {min}",
-  "INPUT_NUMBER_ABOVE_MAX": "A entrada não deve ser maior que {max}",
+  "INPUT_NUMBER_BELOW_MIN": "O valor não deve ser menor que {min}",
+  "INPUT_NUMBER_ABOVE_MAX": "O valor não deve ser maior que {max}",
   "POSITION_INVALID": "A Posição fornecida é inválida",
   "INPUT_TOO_SHORT": "A entrada deve ter pelo menos {limit} caracteres",
   "INPUT_TOO_LONG": "A entrada deve ter no máximo {limit} caracteres"

--- a/src/i18n/error/error.pt.json
+++ b/src/i18n/error/error.pt.json
@@ -6,8 +6,8 @@
   "INPUT_REQUIRED": "Este campo é obrigatório",
   "INPUT_NOT_NUMBER": "Por favor, insira um número",
   "INPUT_NOT_INTEGER": "Por favor, insira um número inteiro",
-  "INPUT_NUMBER_BELOW_MIN": "A entrada não deve ser menor que {value}",
-  "INPUT_NUMBER_ABOVE_MAX": "A entrada não deve ser maior que {value}",
+  "INPUT_NUMBER_BELOW_MIN": "A entrada não deve ser menor que {min}",
+  "INPUT_NUMBER_ABOVE_MAX": "A entrada não deve ser maior que {max}",
   "POSITION_INVALID": "A Posição fornecida é inválida",
   "INPUT_TOO_SHORT": "A entrada deve ter pelo menos {limit} caracteres",
   "INPUT_TOO_LONG": "A entrada deve ter no máximo {limit} caracteres"

--- a/src/i18n/tricks/new/tricksNew.en.json
+++ b/src/i18n/tricks/new/tricksNew.en.json
@@ -23,7 +23,7 @@
 
   "question": {
     "alias": "What do you actually call this?",
-    "difficulty": "1 to 10. Keep empty if unsure.",
+    "difficulty": "1 to 20. Keep empty if unsure.",
     "tips": "Put each tip on a separate line.",
     "variantOf": "Is this a variant of another trick?",
     "recommendedPrereq": "Tricks you would recommend to learn before trying this one?"

--- a/src/i18n/tricks/new/tricksNew.es.json
+++ b/src/i18n/tricks/new/tricksNew.es.json
@@ -23,7 +23,7 @@
 
   "question": {
     "alias": "Cómo llamas realmente a esto?",
-    "difficulty": "1 a 10. Manténte vacía si no está seguro.",
+    "difficulty": "1 a 20. Manténte vacía si no está seguro.",
     "tips": "Pon cada punta en una línea separada.",
     "variantOf": "Es esta una variante de otro truco?",
     "recommendedPrereq": "Trucos que recomendarías aprender antes de probar esto?"

--- a/src/i18n/tricks/new/tricksNew.fr.json
+++ b/src/i18n/tricks/new/tricksNew.fr.json
@@ -23,7 +23,7 @@
 
   "question": {
     "alias": "Qu'est-ce que vous appelez-vous vraiment ceci ?",
-    "difficulty": "1 à 10. Restez vides en cas de doute.",
+    "difficulty": "1 à 20. Restez vides en cas de doute.",
     "tips": "Placez chaque embout sur une ligne distincte.",
     "variantOf": "S'agit-il d'une variante d'une autre trick ?",
     "recommendedPrereq": "Des tricks que vous recommanderiez d'apprendre avant d'essayer celle-ci ?"

--- a/src/i18n/tricks/new/tricksNew.pt.json
+++ b/src/i18n/tricks/new/tricksNew.pt.json
@@ -18,7 +18,7 @@
 
   "question": {
     "alias": "Como você chama isso?",
-    "difficulty": "1 a 10. Deixe em branco se não tiver certeza.",
+    "difficulty": "1 a 20. Deixe em branco se não tiver certeza.",
     "tips": "Coloque cada dica em uma linha separada.",
     "variantOf": "Esta é uma variação de outro truque?",
     "recommendedPrereq": "Tricks que você recomendaria aprender antes de tentar este?"

--- a/src/routes/tricks/NewTrickRoute.vue
+++ b/src/routes/tricks/NewTrickRoute.vue
@@ -9,8 +9,6 @@ import { toTypedSchema } from '@vee-validate/zod';
 
 import messages from '@/i18n/tricks/new/index';
 import messagesPositions from '@/i18n/common/positions';
-import messagesErrors from '@/i18n/error';
-
 import { i18nMerge } from '@/i18n/i18nmerge';
 import { DbPositionZod } from '@/lib/database/schemas/CurrentVersionSchema';
 import { CreateNewTrickType } from '@/lib/database/daos/tricksDao';
@@ -30,7 +28,7 @@ const toast = useToast();
 const router = useRouter();
 
 const { t } = useI18n({
-  messages: i18nMerge(messages, messagesPositions, messagesErrors),
+  messages: i18nMerge(messages, messagesPositions),
   scope: 'local',
 });
 
@@ -41,9 +39,9 @@ const newTrickSchema = z.object({
   difficulty: z.union([
     z
       .number()
-      .int({ message: t('INPUT_NOT_INTEGER') })
-      .min(1, { message: t('INPUT_NUMBER_BELOW_MIN', { value: 1 }) })
-      .max(20, { message: t('INPUT_NUMBER_ABOVE_MAX', { value: 20 }) }),
+      .int({ message: 'INPUT_NOT_INTEGER' })
+      .min(1, { message: 'INPUT_NUMBER_BELOW_MIN' })
+      .max(20, { message: 'INPUT_NUMBER_ABOVE_MAX' }),
     z.literal(''), // When input with type="numeric" is empty it sends an empty string, this works as the `.optional()`
   ]),
   startPosition: DbPositionZod,
@@ -67,11 +65,9 @@ const newTrickSchema = z.object({
   yearEstablished: z.union([
     z
       .number()
-      .int({ message: t('INPUT_NOT_INTEGER') })
-      .min(1900, { message: t('INPUT_NUMBER_BELOW_MIN', { value: 1900 }) })
-      .max(new Date().getFullYear(), {
-        message: t('INPUT_NUMBER_ABOVE_MAX', { value: new Date().getFullYear() }),
-      })
+      .int({ message: 'INPUT_NOT_INTEGER' })
+      .min(1900, { message: 'INPUT_NUMBER_BELOW_MIN' })
+      .max(new Date().getFullYear(), { message: 'INPUT_NUMBER_ABOVE_MAX' })
       .optional(),
     z.literal(''), // When input with type="numeric" is empty it sends an empty string, this works as the `.optional()`
   ]),
@@ -190,6 +186,7 @@ function hasHistory(): boolean {
           form-field-name="difficulty"
           inputMode="numeric"
           type="number"
+          :error-values="{ min: '1', max: '20' }"
         />
 
         <MultilineTextInput
@@ -214,6 +211,7 @@ function hasHistory(): boolean {
           form-field-name="yearEstablished"
           inputMode="numeric"
           type="number"
+          :error-values="{ min: '1900', max: new Date().getFullYear().toString() }"
         />
 
         <MultilineTextInput

--- a/src/routes/tricks/NewTrickRoute.vue
+++ b/src/routes/tricks/NewTrickRoute.vue
@@ -8,7 +8,9 @@ import { h } from 'vue';
 import { toTypedSchema } from '@vee-validate/zod';
 
 import messages from '@/i18n/tricks/new/index';
-import messages_positions from '@/i18n/common/positions';
+import messagesPositions from '@/i18n/common/positions';
+import messagesErrors from '@/i18n/error';
+
 import { i18nMerge } from '@/i18n/i18nmerge';
 import { DbPositionZod } from '@/lib/database/schemas/CurrentVersionSchema';
 import { CreateNewTrickType } from '@/lib/database/daos/tricksDao';
@@ -28,7 +30,7 @@ const toast = useToast();
 const router = useRouter();
 
 const { t } = useI18n({
-  messages: i18nMerge(messages, messages_positions),
+  messages: i18nMerge(messages, messagesPositions, messagesErrors),
   scope: 'local',
 });
 
@@ -36,12 +38,14 @@ const newTrickSchema = z.object({
   technicalName: z.string().trim().min(1),
   alias: z.string().optional(),
   establishedBy: z.string().optional(),
-  difficulty: z
-    .number()
-    .int({ message: 'INPUT_NOT_INTEGER' })
-    .min(1, { message: 'INPUT_NUMBER_BELOW_MIN' })
-    .max(10, { message: 'INPUT_NUMBER_ABOVE_MAX' })
-    .optional(),
+  difficulty: z.union([
+    z
+      .number()
+      .int({ message: t('INPUT_NOT_INTEGER') })
+      .min(1, { message: t('INPUT_NUMBER_BELOW_MIN', { value: 1 }) })
+      .max(10, { message: t('INPUT_NUMBER_ABOVE_MAX', { value: 10 }) }),
+    z.literal(''), // When input with type="numeric" is empty it sends an empty string, this works as the `.optional()`
+  ]),
   startPosition: DbPositionZod,
   endPosition: DbPositionZod,
   description: z.string().optional(),
@@ -60,11 +64,17 @@ const newTrickSchema = z.object({
       z.array(z.string().min(1)).optional()
     )
     .optional(),
-  yearEstablished: z
-    .number()
-    .int({ message: 'INPUT_NOT_INTEGER' })
-    .min(1900, { message: 'INPUT_NUMBER_BELOW_MIN' })
-    .optional(),
+  yearEstablished: z.union([
+    z
+      .number()
+      .int({ message: t('INPUT_NOT_INTEGER') })
+      .min(1900, { message: t('INPUT_NUMBER_BELOW_MIN', { value: 1900 }) })
+      .max(new Date().getFullYear(), {
+        message: t('INPUT_NUMBER_ABOVE_MAX', { value: new Date().getFullYear() }),
+      })
+      .optional(),
+    z.literal(''), // When input with type="numeric" is empty it sends an empty string, this works as the `.optional()`
+  ]),
   // variantOf: z.unknown().optional(), // will be added later
   // recommendedPrerequisites: z.unknown().optional(), // will be added later,
   // videos: z.array(DbVideoZod).optional(),
@@ -86,12 +96,12 @@ const submit = form.handleSubmit(async (vals) => {
     alias: vals.alias,
     dateAddedEpoch: new Date().getTime(),
     establishedBy: vals.establishedBy,
-    difficultyLevel: vals.difficulty,
+    difficultyLevel: vals.difficulty === '' ? undefined : vals.difficulty,
     startPosition: vals.startPosition,
     endPosition: vals.endPosition,
     description: vals.description,
     tips: vals.tips,
-    yearEstablished: vals.yearEstablished,
+    yearEstablished: vals.yearEstablished === '' ? undefined : vals.yearEstablished,
     recommendedPrerequisites: [],
     variationOf: [],
     showInSearchQueries: true,
@@ -178,6 +188,8 @@ function hasHistory(): boolean {
           :description="t('question.difficulty')"
           :placeholder="t('placeholder.difficulty')"
           form-field-name="difficulty"
+          inputMode="numeric"
+          type="number"
         />
 
         <MultilineTextInput
@@ -200,6 +212,8 @@ function hasHistory(): boolean {
           :title="t('label.inTheYear')"
           placeholder="2024"
           form-field-name="yearEstablished"
+          inputMode="numeric"
+          type="number"
         />
 
         <MultilineTextInput

--- a/src/routes/tricks/NewTrickRoute.vue
+++ b/src/routes/tricks/NewTrickRoute.vue
@@ -43,7 +43,7 @@ const newTrickSchema = z.object({
       .number()
       .int({ message: t('INPUT_NOT_INTEGER') })
       .min(1, { message: t('INPUT_NUMBER_BELOW_MIN', { value: 1 }) })
-      .max(10, { message: t('INPUT_NUMBER_ABOVE_MAX', { value: 10 }) }),
+      .max(20, { message: t('INPUT_NUMBER_ABOVE_MAX', { value: 20 }) }),
     z.literal(''), // When input with type="numeric" is empty it sends an empty string, this works as the `.optional()`
   ]),
   startPosition: DbPositionZod,


### PR DESCRIPTION
Fixes #362 

# How to test

Go to the new trick page and try to mess with difficulty and year fields.

DIfficulty should raise an error message if `0` or less as also if `11` or more. If the field is empty it should no error.

Year should raise an error if less than `1900` and if more than the current year (I added this validations, I don't think it makes sense to have a trick stablished at the future)