### PR TITLE
Add menu to redirect to trick creation page or suggest new official trick

### DIFF
--- a/src/i18n/list/list.en.json
+++ b/src/i18n/list/list.en.json
@@ -14,5 +14,9 @@
   },
   "info": {
     "noTrickMatchingSearch": "Oh no. There are not tricks matching your search input."
+  },
+  "newTrickButton": {
+    "personal": "New Personal Trick",
+    "official": "Suggest Official Trick"
   }
 }

--- a/src/i18n/list/list.es.json
+++ b/src/i18n/list/list.es.json
@@ -14,5 +14,9 @@
   },
   "info": {
     "noTrickMatchingSearch": "Oh, no. No hay trucos que coincidan con su búsqueda."
+  },
+  "newTrickButton": {
+    "personal": "Nuevo truco personal",
+    "official": "Sugerir truco oficial"
   }
 }

--- a/src/i18n/list/list.fr.json
+++ b/src/i18n/list/list.fr.json
@@ -14,5 +14,9 @@
   },
   "info": {
     "noTrickMatchingSearch": "Oh non. Il n'y a pas de tricks correspondant à votre recherche."
+  },
+  "newTrickButton": {
+    "personal": "Nouvelle trick personnelle",
+    "official": "Suggérer un trick officiel"
   }
 }

--- a/src/layouts/DefaultLayout.vue
+++ b/src/layouts/DefaultLayout.vue
@@ -4,7 +4,7 @@ import NavbarBottom from '../components/navbar/NavbarBottom.vue';
 </script>
 
 <template>
-  <div class="flex flex-col min-h-screen bg-background text-foreground m-0 p-0">
+  <div class="min-h-screen w-full bg-background text-foreground m-0 p-0">
     <div class="flex flex-row m-0 p-0">
       <div class="hidden lg:block">
         <NavbarSide />

--- a/src/routes/tricks/TrickList.vue
+++ b/src/routes/tricks/TrickList.vue
@@ -11,6 +11,15 @@ import TrickSearchMenu from '@/components/stickable/list/TrickSearchMenu.vue';
 import StickableOverviewCard from '@/components/stickable/list/StickableOverviewCard.vue';
 import Separator from '@/components/ui/separator/Separator.vue';
 import Section from '@/components/ui/section/Section.vue';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+  DropdownMenuSeparator,
+} from '@/components/ui/dropdown-menu';
+import { Button } from '@/components/ui/button';
+import { Icon } from '@iconify/vue/dist/iconify.js';
 
 import { useI18n } from 'vue-i18n';
 import { i18nMerge } from '@/i18n/i18nmerge';
@@ -137,5 +146,37 @@ function linkToDetails(primaryKey: PrimaryKey): string {
         </div>
       </div>
     </Section>
+
+    <!-- Floating Add-New-Trick-Menu -->
+    <DropdownMenu>
+      <DropdownMenuTrigger as-child>
+        <Button
+          size="icon"
+          class="rounded-full shadow-md fixed bottom-20 right-3 lg:bottom-5 lg:right-5 xl:bottom-10 xl:right-10 h-12 w-12"
+        >
+          <Icon icon="ic:round-add" class="h-8 w-8" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent>
+        <DropdownMenuItem>
+          <RouterLink to="/tricks/new" class="flex flex-row">
+            <Icon icon="ic:round-person" class="h-6 w-6 mr-2" />
+            {{ t('newTrickButton.personal') }}
+          </RouterLink>
+        </DropdownMenuItem>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem>
+          <a
+            href="https://forms.gle/kCPLnDz9xNLW9oKAA"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="flex flex-row underline"
+          >
+            <Icon icon="material-symbols:globe-asia" class="h-6 w-6 mr-2" />
+            {{ t('newTrickButton.official') }}
+          </a>
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
   </DefaultLayout>
 </template>


### PR DESCRIPTION
Addresses #365 and a bit more

# Description
- Adds a Plus-Button at the bottom right of the Trick List which opens a two item menu on click
- The first option "New Personal Trick" redirects to the trick creation page (`/tricks/new`). There is no issue for this but it was necessary since a while anyways
- The second option is a link to the Google Form to suggest new official tricks (https://forms.gle/kCPLnDz9xNLW9oKAA). Yes the link is hard-coded, no this is not a relevant issue at the moment.
- Translations into English, French and Spanish

# Limits / Issues
- Missing translation into Portuguese 
- The Plus-Button is not positioned optimally on larger Desktop screens. Might be something to look into in the future. But we are building primarily for Mobile anyways and the issue is purely one of aesthetics, not one of functionality.

# Screenshot
![Screen Shot 2025-03-07 at 11 10 17](https://github.com/user-attachments/assets/7b42dd1d-f0d5-42fe-b808-d92b4dbd0d6c)
