### PR TITLE
Intial value to difficulty so it don't raise an wrong error

### DIFF
--- a/src/i18n/error/error.pt.json
+++ b/src/i18n/error/error.pt.json
@@ -3,7 +3,7 @@
   "home": "Início",
   "debug-info": "Informações de depuração",
 
-  "INPUT_REQUIRED": "Este campo é obrigatório",
+  "Required": "Este campo é obrigatório",
   "INPUT_NOT_NUMBER": "Por favor, insira um número",
   "INPUT_NOT_INTEGER": "Por favor, insira um número inteiro",
   "INPUT_NUMBER_BELOW_MIN": "O valor não deve ser menor que {min}",

--- a/src/routes/tricks/NewTrickRoute.vue
+++ b/src/routes/tricks/NewTrickRoute.vue
@@ -78,11 +78,12 @@ const newTrickSchema = z.object({
 export type NewTrickSchema = z.infer<typeof newTrickSchema>;
 const validationSchema = toTypedSchema(newTrickSchema);
 
-const form = useForm({
+const form = useForm<NewTrickSchema>({
   validationSchema: validationSchema,
   initialValues: {
     startPosition: DbPositionZod.Values.Buddha,
     endPosition: DbPositionZod.Values['Double Drop Knee'],
+    difficulty: '',
   },
 });
 


### PR DESCRIPTION
Fixes #373 

# The issue

After further exploration I found that the field was accepting an empty value, but it was necessary to type something and delete

The possible values for the fields are a `number` or an empty string `""` that enables it to be optional, but the initial value was `undefined`, making it fail on the zod validation

The data flow of typing and deleting was **undefined => value => ""**

# The fix

Add `difficulty: ''` to the useForm initialValues so it doesn't start as undefined and the validation works nicely.

# How to test

Open the `tricks/new` page, type a technical name and save it, it should work.