### PR TITLE
feat: update About page look slightly and its texts

### DIFF
--- a/src/i18n/about/about.en.json
+++ b/src/i18n/about/about.en.json
@@ -6,13 +6,13 @@
   "rewriteInfo": {
     "title": "The new version is here!",
     "content": {
-      "info": "The {debt} got too big and a collective decision was made to fully rewrite the app. After two years of on and off development it is finally here. What's new? Mainly fewer bugs and a project which is maintainable long term.{newline}Since the change was so big and the old data quite inconsistent we were sadly not able to port your tricks and stick frequencies over from the old app. We are super sorry about this! We have systems in place now for this not to happen again.",
+      "info": "The {debt} got too big and a collective decision was made to fully rewrite the app. After over two years of on and off development it is finally here. What's new? Mainly fewer bugs and a project which is maintainable long term.{newline}Since the change was so big and the old data quite inconsistent we were sadly not able to port your custom tricks from the old app. It is also possible that few of your stick frequencies might have gotten lost when moving to the rewrite. We are super sorry about this! We have systems in place now for this not to happen again.",
       "debt": "technical debt"
     }
   },
   "privacy": {
     "title": "Privacy",
-    "content": "As we are highliners we want to make this app work offline. Thus all your data is stored locally on your device. We will never know about your data, only your browser knows about it!{newline}Beware that the video embeds could place tracking cookies on your device. If you are a developer, have some time on hand and can prevent this hit us up."
+    "content": "As we are highliners we want to make this app work offline. Thus all your data is stored locally on your device. At the moment we store non of your custom tricks or stick frequencies on our server, only your browser knows about them!{newline}Beware that the video embeds could place tracking cookies on your device. If you are a developer, have some time on hand and can prevent this hit us up."
   },
   "contribute": {
     "title": "Contribute or report issues",

--- a/src/i18n/about/about.es.json
+++ b/src/i18n/about/about.es.json
@@ -6,13 +6,13 @@
   "rewriteInfo": {
     "title": "¡Ya está aquí la nueva versión!",
     "content": {
-      "info": "La {debt} se hizo demasiado grande y se tomó la decisión colectiva de reescribir completamente la aplicación. Tras dos años de desarrollo intermitente, por fin está aquí. ¿Cuáles son las novedades? Principalmente menos errores y un proyecto que es mantenible a largo plazo. {newline}Dado que el cambio fue tan grande y los datos antiguos bastante inconsistentes, lamentablemente no pudimos portar sus trucos y frecuencias de palo de la antigua aplicación. Lo sentimos mucho. Ahora tenemos sistemas para que esto no vuelva a ocurrir.",
+      "info": "La {debt} se hizo demasiado grande y se tomó la decisión colectiva de reescribir completamente la aplicación. Después de más de dos años de desarrollo intermitente, por fin está aquí. ¿Qué hay de nuevo? Principalmente, menos errores y un proyecto que se puede mantener a largo plazo.{newline}Dado que el cambio fue tan grande y los datos antiguos eran bastante inconsistentes, lamentablemente no pudimos transferir tus trucos personalizados de la aplicación antigua. También es posible que algunas de tus frecuencias de stick se hayan perdido al pasar a la nueva versión. ¡Lo sentimos mucho! Ahora contamos con sistemas para que esto no vuelva a suceder.",
       "debt": "deuda técnica"
     }
   },
   "privacy": {
     "title": "Privacidad",
-    "content": "Como somos highliners, queremos que esta aplicación funcione sin conexión. Por lo tanto, todos sus datos se almacenan localmente en su dispositivo. Nunca sabremos nada de tus datos, sólo los sabrá tu navegador.{newline}Ten en cuenta que las incrustaciones de vídeo podrían colocar cookies de seguimiento en tu dispositivo. Si eres un desarrollador, tienes algo de tiempo y puedes evitarlo, ponte en contacto con nosotros."
+    "content": "Como somos highliners, queremos que esta aplicación funcione sin conexión. Por lo tanto, todos tus datos se almacenan localmente en tu dispositivo. Por el momento, no almacenamos ninguno de tus trucos personalizados ni frecuencias de stick en nuestro servidor, ¡solo tu navegador los conoce!{newline}Ten en cuenta que los vídeos incrustados podrían colocar cookies de seguimiento en tu dispositivo. Si eres desarrollador, tienes algo de tiempo libre y puedes evitarlo, ponte en contacto con nosotros."
   },
   "contribute": {
     "title": "Contribuir o informar de problemas",

--- a/src/i18n/about/about.fr.json
+++ b/src/i18n/about/about.fr.json
@@ -6,13 +6,13 @@
   "rewriteInfo": {
     "title": "La nouvelle version est arrivée !",
     "content": {
-      "info": "La {debt} est devenue trop importante et une décision collective a été prise de réécrire entièrement l'application. Après deux ans de développement par intermittence, elle est enfin là. Quelles sont les nouveautés ? Principalement moins de bugs et un projet qui peut être maintenu à long terme.{newline}Comme le changement était si important et les anciennes données assez incohérentes, nous n'avons malheureusement pas été en mesure de porter vos trucs et fréquences de l'ancienne application. Nous en sommes vraiment désolés ! Nous avons mis en place des systèmes pour que cela ne se reproduise plus.",
+      "info": "La {debt} était devenue trop importante et une décision collective a été prise de réécrire entièrement l'application. Après plus de deux ans de développement intermittent, elle est enfin disponible. Quelles sont les nouveautés ? Principalement moins de bugs et un projet qui peut être maintenu à long terme.{newline}Comme le changement était très important et que les anciennes données étaient assez incohérentes, nous n'avons malheureusement pas pu transférer vos figures personnalisées depuis l'ancienne application. Il est également possible que certaines de vos fréquences de stick aient été perdues lors du transfert vers la nouvelle version. Nous en sommes vraiment désolés ! Nous avons mis en place des systèmes pour que cela ne se reproduise plus.",
       "debt": "dette technique"
     }
   },
   "privacy": {
     "title": "Vie privée",
-    "content": "Comme nous sommes des highliners, nous voulons que cette application fonctionne hors ligne. Ainsi, toutes vos données sont stockées localement sur votre appareil. Nous ne connaîtrons jamais vos données, seul votre navigateur les connaît ! {newline}Attention, les vidéos intégrées peuvent placer des cookies de suivi sur votre appareil. Si vous êtes un développeur, que vous avez du temps disponible et que vous pouvez empêcher cela, contactez-nous."
+    "content": "En tant que highliners, nous voulons que cette application fonctionne hors ligne. Ainsi, toutes vos données sont stockées localement sur votre appareil. Pour l'instant, nous ne stockons aucune de vos figures personnalisées ni aucune fréquence de stick sur notre serveur, seul votre navigateur en a connaissance !{newline}Sachez que les vidéos intégrées peuvent placer des cookies de suivi sur votre appareil. Si vous êtes développeur, que vous avez du temps libre et que vous pouvez empêcher cela, contactez-nous."
   },
   "contribute": {
     "title": "Contribuer ou signaler des problèmes",

--- a/src/i18n/about/about.pt.json
+++ b/src/i18n/about/about.pt.json
@@ -1,0 +1,24 @@
+{
+  "general": {
+    "title": "Sobre",
+    "content": "Este aplicativo foi criado por atletas apaixonados pelo highline freestyle que desejam ver o esporte crescer. À medida que mais e mais manobras são criadas a cada semana, fica difícil manter uma visão geral. Aqui, queremos mostrar as manobras mais comuns, juntamente com informações importantes para ajudá-lo a aprendê-las."
+  },
+  "rewriteInfo": {
+    "title": "A nova versão já está disponível!",
+    "content": {
+      "info": "A {debt} ficou muito grande e foi tomada uma decisão coletiva de reescrever totalmente a aplicação. Após mais de dois anos de desenvolvimento intermitente, ela finalmente está aqui. O que há de novo? Principalmente menos bugs e um projeto que pode ser mantido a longo prazo.{newline}Como a mudança foi muito grande e os dados antigos bastante inconsistentes, infelizmente não foi possível transferir os seus truques personalizados do aplicativo antigo. Também é possível que algumas das suas frequências de stick tenham sido perdidas durante a reescrita. Lamentamos muito por isso! Agora temos sistemas para que isso não aconteça novamente.",
+      "debt": "dívida técnica"
+    }
+  },
+  "privacy": {
+    "title": "Privacidade",
+    "content": "Como somos adeptos do highline, queremos que esta aplicação funcione offline. Assim, todos os seus dados são armazenados localmente no seu dispositivo. No momento, não armazenamos nenhum dos seus truques personalizados ou frequências de stick no nosso servidor, apenas o seu navegador tem acesso a eles!{newline}Esteja ciente de que os vídeos incorporados podem colocar cookies de rastreamento no seu dispositivo. Se é programador, tem algum tempo disponível e pode impedir isso, entre em contacto connosco."
+  },
+  "contribute": {
+    "title": "Contribua ou reporte problemas",
+    "content": {
+      "info": "Este é um projeto comunitário de código aberto. Ajude-nos a construí-lo, mantê-lo e traduzi-lo!",
+      "github": "Repositório GitHub"
+    }
+  }
+}

--- a/src/i18n/about/index.ts
+++ b/src/i18n/about/index.ts
@@ -1,5 +1,6 @@
 import en from './about.en.json';
 import es from './about.es.json';
 import fr from './about.fr.json';
+import pt from './about.pt.json';
 
-export default { en, es, fr };
+export default { en, es, fr, pt };

--- a/src/routes/About.vue
+++ b/src/routes/About.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { Alert, AlertTitle, AlertDescription } from '@/components/ui/alert';
 import Section from '@/components/ui/section/Section.vue';
 import DefaultLayout from '@/layouts/DefaultLayout.vue';
 import { Icon } from '@iconify/vue/dist/iconify.js';
@@ -20,19 +19,17 @@ const { t } = i18n;
       <h1 class="text-3xl mx-6 md:mx-0 mb-2 mt-5">{{ t('general.title') }}</h1>
       <p class="mt-2 mx-6 md:mx-0">{{ t('general.content') }}</p>
 
-      <Alert class="mx-6 md:mx-0 mt-3 w-fit">
-        <AlertTitle>{{ t('rewriteInfo.title') }}</AlertTitle>
-        <AlertDescription>
-          <i18n-t keypath="rewriteInfo.content.info" tag="p">
-            <template #newline><br class="mb-2" /></template>
-            <template #debt>
-              <a href="https://en.wikipedia.org/wiki/Technical_debt" class="underline">
-                {{ t('rewriteInfo.content.debt') }}
-              </a>
-            </template>
-          </i18n-t>
-        </AlertDescription>
-      </Alert>
+      <h1 class="text-2xl mx-6 md:mx-0 mt-4 mb-2 lg:mt-8">{{ t('rewriteInfo.title') }}</h1>
+      <p class="mt-2 mx-6 md:mr-0">
+        <i18n-t keypath="rewriteInfo.content.info" tag="p">
+          <template #newline><br class="mb-2" /></template>
+          <template #debt>
+            <a href="https://en.wikipedia.org/wiki/Technical_debt" class="underline">
+              {{ t('rewriteInfo.content.debt') }}
+            </a>
+          </template>
+        </i18n-t>
+      </p>
 
       <h1 class="text-2xl mx-6 md:mx-0 mt-4 mb-2 lg:mt-8">{{ t('privacy.title') }}</h1>
       <p class="mt-2 mx-6 md:mr-0">


### PR DESCRIPTION
Implements #385 (translating the About page into Portuguese).

Additional changes
- Slight change of wording in the privacy information (translated into English, Spanish, French and Portuguese)
- Change in the text about the rewrite to explain that some of the data will be ported over and some wont (translated into English, Spanish, French and Portuguese)
- The information about the rewrite is now displayed as a regular section with a title instead of as an alert.