### PR TITLE
feat: make close button on toast always visible

### DIFF
--- a/src/components/ui/toast/ToastClose.vue
+++ b/src/components/ui/toast/ToastClose.vue
@@ -13,7 +13,7 @@ const props = defineProps<{
     v-bind="props"
     :class="
       cn(
-        'absolute right-2 top-2 rounded-md p-1 text-foreground/50 opacity-0 transition-opacity hover:text-foreground focus:opacity-100 focus:outline-none focus:ring-2 group-hover:opacity-100 group-[.destructive]:text-red-300 group-[.destructive]:hover:text-red-50 group-[.destructive]:focus:ring-red-400 group-[.destructive]:focus:ring-offset-red-600',
+        'absolute right-2 top-2 rounded-md p-1 text-foreground/50 opacity-100 transition-opacity hover:text-foreground focus:opacity-100 focus:outline-none focus:ring-2 group-hover:opacity-100 group-[.destructive]:text-red-300 group-[.destructive]:hover:text-red-50 group-[.destructive]:focus:ring-red-400 group-[.destructive]:focus:ring-offset-red-600',
         props.class
       )
     "


### PR DESCRIPTION
Addresses #402 

The standard shadcn vue Toast component only displays a close button on mouse hover. Therefore it was not visible on mobile at all.

After some testing I figured out that shadcn / reka ui wants mobile users to swipe the toasts away. But this was very intuitive to me and not obvious. Therefore I changed the toast in such a way that the close button is always visible. Swiping still works for users that intuitively try to close the toast that way but for all other users there is a visibly reconizable way to go about it as well now. 