### PR TITLE
feat: respect showInSearchQueries flag

### DIFF
--- a/src/services/searchAndFilterTricks.ts
+++ b/src/services/searchAndFilterTricks.ts
@@ -189,8 +189,9 @@ export function searchInTricks(
     ];
   }
 
-  const filteredTricks = allTricks.filter((trick) =>
-    searchParameters.includedStatuses.includes(trick.primaryKey[1])
+  const filteredTricks = allTricks.filter(
+    (trick) =>
+      searchParameters.includedStatuses.includes(trick.primaryKey[1]) && trick.showInSearchQueries
   );
 
   const sortedTricks = sortTricks(filteredTricks, searchParameters.sortOrder);


### PR DESCRIPTION
Implements #405 

Ticks which have the `showInSearchQueries` flag set to `false` are now hidden from the trick overview. The exception to this is when using text search to find tricks, then all tricks are still shown. This behavior is intended.