### PR TITLE
feat: improve loading time for syncing tricks

### DIFF
--- a/src/lib/database/official/syncTricks.ts
+++ b/src/lib/database/official/syncTricks.ts
@@ -152,32 +152,6 @@ async function handleArchiving(archivedTricks: z.infer<typeof DbTricksTableZod>[
   return failedTrickMigrations === 0;
 }
 
-/**
- * Although the odds of a trick that was archived being reintroduced are very, it might still be possible.
- * This will
- * - find metadata belonging to an archived trick and move it to the official trick
- * - move any references to the archived trick back to the official trick
- * - delete the archived trick (creation will happen later)
- */
-async function handleUnarchivingTricks(tricks: z.infer<typeof DbTricksTableZod>[]) {
-  return await Promise.allSettled(
-    tricks.map(async (e) => {
-      await moveTrick(e.id, 'archived', 'official');
-      // At this point references are handled. Now we just need to move the actual Trick over.
-      // This is done using a PUT and DELETE (because again, you cannot modify the Primary Key with Dexie / IndexedDB)
-      const newTrickObject = DbTricksTableZod.parse({
-        ...e,
-        trickStatus: 'official',
-      });
-
-      // PUT'ting the new trick here technically is redundant, but its still here
-      // too keep consistent with the archiving procedure.
-      await db.tricks.put(newTrickObject);
-      await db.tricks.delete([e.id, 'archived']);
-    })
-  );
-}
-
 export default async function syncTricks() {
   const tricks = z
     .array(DbTricksTableZod)
@@ -198,8 +172,6 @@ export default async function syncTricks() {
   if (tricksThatHaveBeenRemoved.length > 0) {
     await handleArchiving(tricksThatHaveBeenRemoved);
   }
-
-  await handleUnarchivingTricks(tricks);
 
   // At this point, the Database should be in a state where all to-be-archived Tricks had their references updated.
   // so we can safely PUT the new tricks into the DB.


### PR DESCRIPTION
Adresses #400 (hopefully).

I assume the issue persisted because loading could take seconds and therefore the impression of the tricks not loading at all could arise. Who knows if this was the issue but it is the only thing I could reproduce.

As a result I improved the loading performance when syncing the tricks from an average of 1957ms (std. dev. 394ms, 5 samples) down to 327ms (std. dev. 40ms, 5 samples) when running a production build (`npm run build && npm run preview`) (though the numbers don't differ significantly when running in development mode (`npm run host`). A performance improvement of around 8x.

This was archieved by fully removing the functionality to unarchive tricks. The function for this was implemented in an inefficient way where it would cause reads (and potential writes) for every trick in the Index DB, whether or not it had to be unarchived. This removal alone was responsible for the performance improvement.

But Julian, I hear you say, you can't simply improve performance by throwing out functionality at the core of the app. That's what I thought too. At first. But as I pondered what unarchiving actually does and the edge cases it has I came to the conclusion that removing it was the best step forward:

Unarchiving did the following: If there was a trick with an id `A` and a status `archived` in the Index DB and there was a trick with the same id `A` in the trick yml files to be added to the database, the function would detect that and
1. Create a new Trick with id `A` and status `official` in the database
2. Add all the information of the trick in the yml files to the entry in the database
3. Point the metadata of the original archived trick in the database to the new entry
4. Finally delete the old entry

This way if a trick was removed from the official tricks but was added back again, the metadata of the user could be preserved for that trick. That is, _if_, and only if, the user didn't choose to convert the archived trick into a userDefined trick yet. If the user does that there is no way to safely unarchive it again as official tricks and userDefined tricks can have the same id whilst being completely independant and different tricks.

So unarchiving was used in the rare case that a trick would be removed from the official trick and added back again. That shouldn't be a common occurrence. And then in addition to that it doesn't work in all cases. And yet on top of that, it does not cause any issues if this behavior does not exists. If unarchiving is not in the code and an official trick is reintroduced, then it will simply be in the users trick list twice. Once as official, once archived. Not great but it won't be causing any bugs either, plus, it is actually fairly understandable to the user. They see two versions of the trick, one with an "archived" Badge and old data, one that looks like an official trick but with new data. For something that shouldn't happen in the first place this seems reasonable enough.