### PR TITLE
Trick-list sort UX, big perf pass, and a stick-frequency sort option

### DIFF
--- a/src/components/stickable/list/StickFrequencyLongPressPopover.vue
+++ b/src/components/stickable/list/StickFrequencyLongPressPopover.vue
@@ -6,6 +6,7 @@ import { Popover, PopoverContent } from '@/components/ui/popover';
 import TrickStickFrequencySelector from '@/components/stickable/stickFrequencySelector/TrickStickFrequencySelector.vue';
 import type { StickableStatus } from '@/lib/utils';
 import { stickFrequencyOverridesKey, frequencyOverrideKey } from './stickFrequencyOverridesKey';
+import { trickListRefreshKey } from './trickListContext';
 import { reportNestedPopoverOpen, usePopoverAutoClose } from '@/composables/usePopoverAutoClose';
 
 const props = defineProps<{
@@ -27,8 +28,19 @@ const hasInteracted = ref(false);
 // re-renders only the card(s) that read this key — no list-wide cascade.
 const overrides = inject(stickFrequencyOverridesKey, null);
 
+// Host can also provide a refresh callback so we can re-fetch the cached
+// trick array after the user commits a change. Deferred until the popover
+// closes so the section grouping doesn't shift the card out from under the
+// user's finger mid-gesture.
+const requestTrickListRefresh = inject(trickListRefreshKey, null);
+let needsRefreshAfterClose = false;
+
 function onChange(frequency: number) {
   overrides?.set(frequencyOverrideKey([props.trickId, props.trickStatus]), frequency);
+}
+
+function onCommit() {
+  needsRefreshAfterClose = true;
 }
 
 const LONG_PRESS_DELAY = 500;
@@ -166,6 +178,16 @@ const placeholderStyle = computed(() => {
 const { isRouteLeaving } = usePopoverAutoClose(containerRef, isOpen);
 reportNestedPopoverOpen(isOpen);
 
+// Refresh the host trick list only once the popover is fully closed, so the
+// card doesn't teleport into a different section while the user is still
+// looking at the slider.
+watch(isOpen, (open) => {
+  if (open) return;
+  if (!needsRefreshAfterClose) return;
+  needsRefreshAfterClose = false;
+  requestTrickListRefresh?.();
+});
+
 // Belt-and-suspenders: even if pointer events were lost, route navigation and
 // KeepAlive deactivation must never leave the ghost teleported to body.
 onBeforeRouteLeave(() => endPress());
@@ -232,6 +254,7 @@ onUnmounted(() => {
         :trick-id="props.trickId"
         :trick-status="props.trickStatus"
         @change="onChange"
+        @commit="onCommit"
       />
     </PopoverContent>
   </Popover>

--- a/src/components/stickable/list/trickListContext.ts
+++ b/src/components/stickable/list/trickListContext.ts
@@ -1,0 +1,11 @@
+import type { InjectionKey } from 'vue';
+
+export type TrickListRefresh = () => void | Promise<void>;
+
+// Provided by the trick list view so descendants (e.g. the long-press
+// stick-frequency popover) can request a re-fetch of the cached trick array
+// after they commit a change. Without this, the list's section grouping
+// keeps using the stale value until the next KeepAlive reactivation, so a
+// trick whose stick frequency just changed stays in its old section even
+// though the card colour already reflects the new value.
+export const trickListRefreshKey: InjectionKey<TrickListRefresh> = Symbol('trickListRefresh');

--- a/src/components/stickable/stickFrequencySelector/TrickStickFrequencySelector.vue
+++ b/src/components/stickable/stickFrequencySelector/TrickStickFrequencySelector.vue
@@ -20,6 +20,7 @@ const props = defineProps<{
 
 const emit = defineEmits<{
   change: [frequency: number];
+  commit: [frequency: number];
 }>();
 
 const { toast } = useToast();
@@ -67,6 +68,7 @@ async function onCommit(frequencyArr: [number]) {
     trick.stickFrequency = frequency;
     await trick.persist();
     lastCommittedFrequency = frequency;
+    emit('commit', frequency);
   } catch (err) {
     frequencyModel.value = [lastCommittedFrequency];
     emit('change', lastCommittedFrequency);

--- a/src/components/ui/collapsible/CollapsibleContent.vue
+++ b/src/components/ui/collapsible/CollapsibleContent.vue
@@ -14,19 +14,14 @@ const isAnimating = ref(false);
 function onAnimationStart(e: AnimationEvent) {
   if (e.target === e.currentTarget) isAnimating.value = true;
 }
-function onAnimationEnd(e: AnimationEvent) {
-  if (e.target !== e.currentTarget) return;
-  isAnimating.value = false;
-  // KeepAlive deactivation removes this element from the document and
-  // reactivation reinserts it. CSS spec restarts any matching animation rule
-  // on reinsertion, so an open Collapsible would replay its expand
-  // animation every time the user returns from a child route. Pin
-  // animation-name to 'none' once the user-triggered animation has finished —
-  // reka's watcher resets this on the next isOpen toggle, so real
-  // open/close gestures still animate normally.
-  (e.currentTarget as HTMLElement).style.animationName = 'none';
-}
-function onAnimationCancel(e: AnimationEvent) {
+// KeepAlive deactivation removes this element from the document and
+// reactivation reinserts it. CSS spec restarts any matching animation rule
+// on reinsertion, so an open Collapsible would replay its expand animation
+// every time the user returns from a child route. Pin animation-name to
+// 'none' once the user-triggered animation has finished — reka's watcher
+// resets this on the next isOpen toggle, so real open/close gestures still
+// animate normally.
+function onAnimationDone(e: AnimationEvent) {
   if (e.target !== e.currentTarget) return;
   isAnimating.value = false;
   (e.currentTarget as HTMLElement).style.animationName = 'none';
@@ -39,8 +34,8 @@ function onAnimationCancel(e: AnimationEvent) {
     class="overflow-hidden transition-all data-[state=closed]:animate-collapsible-up data-[state=open]:animate-collapsible-down"
     :class="!isAnimating ? 'data-[state=open]:overflow-visible' : ''"
     @animationstart="onAnimationStart"
-    @animationend="onAnimationEnd"
-    @animationcancel="onAnimationCancel"
+    @animationend="onAnimationDone"
+    @animationcancel="onAnimationDone"
   >
     <slot />
   </CollapsibleContent>

--- a/src/i18n/list/list.en.json
+++ b/src/i18n/list/list.en.json
@@ -3,7 +3,17 @@
     "difficulty": "Difficulty {difficulty}",
     "unknown": "Unknown",
     "notDetermined": "Not determined",
-    "favorites": "Favorites"
+    "favorites": "Favorites",
+    "stickFrequency": {
+      "0": "Never tried",
+      "1": "Practicing",
+      "2": "Once",
+      "3": "Rarely",
+      "4": "Sometimes",
+      "5": "Often",
+      "6": "Generally",
+      "7": "Always"
+    }
   },
   "cards": {
     "level": "Lvl {level}",

--- a/src/i18n/list/list.en.json
+++ b/src/i18n/list/list.en.json
@@ -5,14 +5,14 @@
     "notDetermined": "Not determined",
     "favorites": "Favorites",
     "stickFrequency": {
-      "0": "Never tried",
-      "1": "Practicing",
-      "2": "Once",
-      "3": "Rarely",
-      "4": "Sometimes",
-      "5": "Often",
-      "6": "Generally",
-      "7": "Always"
+      "neverTried": "Never tried",
+      "practicing": "Practicing",
+      "once": "Once",
+      "rarely": "Rarely",
+      "sometimes": "Sometimes",
+      "often": "Often",
+      "generally": "Generally",
+      "always": "Always"
     }
   },
   "cards": {

--- a/src/i18n/list/list.es.json
+++ b/src/i18n/list/list.es.json
@@ -3,7 +3,17 @@
     "difficulty": "Dificultad {difficulty}",
     "unknown": "Desconocido",
     "notDetermined": "No determinado",
-    "favorites": "Favoritos"
+    "favorites": "Favoritos",
+    "stickFrequency": {
+      "0": "Nunca probado",
+      "1": "Practicar",
+      "2": "Una vez",
+      "3": "Raramente",
+      "4": "En ocasiones",
+      "5": "A menudo",
+      "6": "En general",
+      "7": "Siempre"
+    }
   },
   "cards": {
     "level": "Nvl {level}",

--- a/src/i18n/list/list.es.json
+++ b/src/i18n/list/list.es.json
@@ -5,14 +5,14 @@
     "notDetermined": "No determinado",
     "favorites": "Favoritos",
     "stickFrequency": {
-      "0": "Nunca probado",
-      "1": "Practicar",
-      "2": "Una vez",
-      "3": "Raramente",
-      "4": "En ocasiones",
-      "5": "A menudo",
-      "6": "En general",
-      "7": "Siempre"
+      "neverTried": "Nunca probado",
+      "practicing": "Practicar",
+      "once": "Una vez",
+      "rarely": "Raramente",
+      "sometimes": "En ocasiones",
+      "often": "A menudo",
+      "generally": "En general",
+      "always": "Siempre"
     }
   },
   "cards": {

--- a/src/i18n/list/list.fr.json
+++ b/src/i18n/list/list.fr.json
@@ -3,7 +3,17 @@
     "difficulty": "Difficulté {difficulty}",
     "unknown": "Inconnu",
     "notDetermined": "Non déterminé",
-    "favorites": "Favoris"
+    "favorites": "Favoris",
+    "stickFrequency": {
+      "0": "Jamais essayé",
+      "1": "Pratiquer",
+      "2": "Une fois",
+      "3": "Rarement",
+      "4": "Parfois",
+      "5": "Souvent",
+      "6": "En général",
+      "7": "Toujours"
+    }
   },
   "cards": {
     "level": "Nv {level}",

--- a/src/i18n/list/list.fr.json
+++ b/src/i18n/list/list.fr.json
@@ -5,14 +5,14 @@
     "notDetermined": "Non déterminé",
     "favorites": "Favoris",
     "stickFrequency": {
-      "0": "Jamais essayé",
-      "1": "Pratiquer",
-      "2": "Une fois",
-      "3": "Rarement",
-      "4": "Parfois",
-      "5": "Souvent",
-      "6": "En général",
-      "7": "Toujours"
+      "neverTried": "Jamais essayé",
+      "practicing": "Pratiquer",
+      "once": "Une fois",
+      "rarely": "Rarement",
+      "sometimes": "Parfois",
+      "often": "Souvent",
+      "generally": "En général",
+      "always": "Toujours"
     }
   },
   "cards": {

--- a/src/i18n/list/list.pt.json
+++ b/src/i18n/list/list.pt.json
@@ -5,14 +5,14 @@
     "notDetermined": "Não definida",
     "favorites": "Favoritos",
     "stickFrequency": {
-      "0": "Nunca tentei",
-      "1": "Praticando",
-      "2": "Uma vez",
-      "3": "Raramente",
-      "4": "Às vezes",
-      "5": "Frequentemente",
-      "6": "Geralmente",
-      "7": "Sempre"
+      "neverTried": "Nunca tentei",
+      "practicing": "Praticando",
+      "once": "Uma vez",
+      "rarely": "Raramente",
+      "sometimes": "Às vezes",
+      "often": "Frequentemente",
+      "generally": "Geralmente",
+      "always": "Sempre"
     }
   },
   "cards": {

--- a/src/i18n/list/list.pt.json
+++ b/src/i18n/list/list.pt.json
@@ -3,7 +3,17 @@
     "difficulty": "Dificuldade {difficulty}",
     "unknown": "Desconhecida",
     "notDetermined": "Não definida",
-    "favorites": "Favoritos"
+    "favorites": "Favoritos",
+    "stickFrequency": {
+      "0": "Nunca tentei",
+      "1": "Praticando",
+      "2": "Uma vez",
+      "3": "Raramente",
+      "4": "Às vezes",
+      "5": "Frequentemente",
+      "6": "Geralmente",
+      "7": "Sempre"
+    }
   },
   "cards": {
     "level": "Nv {level}",

--- a/src/i18n/searchMenu/searchMenu.en.json
+++ b/src/i18n/searchMenu/searchMenu.en.json
@@ -8,6 +8,7 @@
     "startPosition": "Start Position",
     "endPosition": "End Position",
     "inventionYear": "Invention year",
+    "stickFrequency": "Stick frequency",
     "ascending": "Ascending",
     "descending": "Descending"
   }

--- a/src/i18n/searchMenu/searchMenu.es.json
+++ b/src/i18n/searchMenu/searchMenu.es.json
@@ -8,6 +8,7 @@
     "startPosition": "Posición inicial",
     "endPosition": "Posición final",
     "inventionYear": "Intenvtion year",
+    "stickFrequency": "Frecuencia de aciertos",
     "ascending": "Ascendente",
     "descending": "Descendente"
   }

--- a/src/i18n/searchMenu/searchMenu.fr.json
+++ b/src/i18n/searchMenu/searchMenu.fr.json
@@ -8,6 +8,7 @@
     "startPosition": "Position initiale",
     "endPosition": "Position finale",
     "inventionYear": "Année d'invention",
+    "stickFrequency": "Fréquence de réussite",
     "ascending": "Croissant",
     "descending": "Décroissant"
   }

--- a/src/i18n/searchMenu/searchMenu.pt.json
+++ b/src/i18n/searchMenu/searchMenu.pt.json
@@ -8,6 +8,7 @@
     "startPosition": "Posição inicial",
     "endPosition": "Posição final",
     "inventionYear": "Ano de criação",
+    "stickFrequency": "Frequência de acerto",
     "ascending": "Crescente",
     "descending": "Decrescente"
   }

--- a/src/routes/tricks/TrickList.vue
+++ b/src/routes/tricks/TrickList.vue
@@ -38,6 +38,7 @@ import {
   stickFrequencyOverrides,
   stickFrequencyOverridesKey,
 } from '@/components/stickable/list/stickFrequencyOverridesKey';
+import { trickListRefreshKey } from '@/components/stickable/list/trickListContext';
 import Separator from '@/components/ui/separator/Separator.vue';
 import Section from '@/components/ui/section/Section.vue';
 import { Collapsible, CollapsibleTrigger, CollapsibleContent } from '@/components/ui/collapsible';
@@ -340,10 +341,13 @@ function trickToAttribute(trick: Trick, sortOption: SortOrder): string {
     case 'yearEstablished-desc':
       return trick.yearEstablished ? trick.yearEstablished.toString() : t('sectionTitles.unknown');
     case 'stickFrequency-asc':
-    case 'stickFrequency-desc':
-      return trick.stickFrequency != null && trick.stickFrequency in STICK_FREQUENCY_TITLE_KEYS
-        ? t(`sectionTitles.stickFrequency.${STICK_FREQUENCY_TITLE_KEYS[trick.stickFrequency]}`)
-        : t('sectionTitles.unknown');
+    case 'stickFrequency-desc': {
+      // Treat an unset stickFrequency as 0 ('Never tried') to match what the
+      // card colour and the long-press slider already show for the same data.
+      const freq = trick.stickFrequency ?? 0;
+      const key = STICK_FREQUENCY_TITLE_KEYS[freq];
+      return key ? t(`sectionTitles.stickFrequency.${key}`) : t('sectionTitles.unknown');
+    }
   }
 }
 
@@ -385,6 +389,11 @@ async function loadTricks() {
 // (long-press popover, cards) keep their inject path. Details view writes to
 // the same singleton directly via import.
 provide(stickFrequencyOverridesKey, stickFrequencyOverrides);
+// Let descendants (e.g. the long-press popover) refresh the trick list cache
+// after they commit a change, so section grouping picks up the new value.
+provide(trickListRefreshKey, () => {
+  loadTricks();
+});
 
 watch(sortOrder, (val) => localStorage.setItem(LOCAL_STORAGE_SORT_KEY, val));
 

--- a/src/routes/tricks/TrickList.vue
+++ b/src/routes/tricks/TrickList.vue
@@ -325,6 +325,11 @@ function trickToAttribute(trick: Trick, sortOption: SortOrder): string {
     case 'yearEstablished-asc':
     case 'yearEstablished-desc':
       return trick.yearEstablished ? trick.yearEstablished.toString() : t('sectionTitles.unknown');
+    case 'stickFrequency-asc':
+    case 'stickFrequency-desc':
+      return trick.stickFrequency != null
+        ? t(`sectionTitles.stickFrequency.${trick.stickFrequency}`)
+        : t('sectionTitles.unknown');
   }
 }
 

--- a/src/routes/tricks/TrickList.vue
+++ b/src/routes/tricks/TrickList.vue
@@ -309,6 +309,20 @@ const poolEntries = computed<PoolEntry[]>(() => {
   return entries;
 });
 
+// Numeric i18n path segments (e.g. `.0`) get interpreted as array indices,
+// so we map each stick-frequency value to a named key in the section title
+// bundle instead of relying on numeric path lookup.
+const STICK_FREQUENCY_TITLE_KEYS = [
+  'neverTried',
+  'practicing',
+  'once',
+  'rarely',
+  'sometimes',
+  'often',
+  'generally',
+  'always',
+] as const;
+
 function trickToAttribute(trick: Trick, sortOption: SortOrder): string {
   switch (sortOption) {
     case 'difficulty-asc':
@@ -327,8 +341,8 @@ function trickToAttribute(trick: Trick, sortOption: SortOrder): string {
       return trick.yearEstablished ? trick.yearEstablished.toString() : t('sectionTitles.unknown');
     case 'stickFrequency-asc':
     case 'stickFrequency-desc':
-      return trick.stickFrequency != null
-        ? t(`sectionTitles.stickFrequency.${trick.stickFrequency}`)
+      return trick.stickFrequency != null && trick.stickFrequency in STICK_FREQUENCY_TITLE_KEYS
+        ? t(`sectionTitles.stickFrequency.${STICK_FREQUENCY_TITLE_KEYS[trick.stickFrequency]}`)
         : t('sectionTitles.unknown');
   }
 }

--- a/src/routes/tricks/TrickList.vue
+++ b/src/routes/tricks/TrickList.vue
@@ -310,9 +310,10 @@ const poolEntries = computed<PoolEntry[]>(() => {
   return entries;
 });
 
-// Numeric i18n path segments (e.g. `.0`) get interpreted as array indices,
-// so we map each stick-frequency value to a named key in the section title
-// bundle instead of relying on numeric path lookup.
+// Map stickFrequency value (0-7) to the named i18n key under
+// `sectionTitles.stickFrequency`. Named keys are used because vue-i18n
+// interprets numeric path segments (e.g. `.0`) as array indices and would
+// not resolve them against an object whose keys are strings.
 const STICK_FREQUENCY_TITLE_KEYS = [
   'neverTried',
   'practicing',
@@ -391,9 +392,7 @@ async function loadTricks() {
 provide(stickFrequencyOverridesKey, stickFrequencyOverrides);
 // Let descendants (e.g. the long-press popover) refresh the trick list cache
 // after they commit a change, so section grouping picks up the new value.
-provide(trickListRefreshKey, () => {
-  loadTricks();
-});
+provide(trickListRefreshKey, loadTricks);
 
 watch(sortOrder, (val) => localStorage.setItem(LOCAL_STORAGE_SORT_KEY, val));
 

--- a/src/routes/tricks/sortingOptions.ts
+++ b/src/routes/tricks/sortingOptions.ts
@@ -10,6 +10,7 @@ export const sortFieldOptions: SortFieldOption[] = [
   { titleKey: 'sortOptions.startPosition', value: 'startPos' },
   { titleKey: 'sortOptions.endPosition', value: 'endPos' },
   { titleKey: 'sortOptions.inventionYear', value: 'yearEstablished' },
+  { titleKey: 'sortOptions.stickFrequency', value: 'stickFrequency' },
 ];
 
 export function parseSortOrder(order: SortOrder): { field: SortField; direction: SortDirection } {

--- a/src/services/searchAndFilterTricks.ts
+++ b/src/services/searchAndFilterTricks.ts
@@ -118,8 +118,13 @@ const compareDifficultyUndefined = compareUndefinedLast((t) => t.difficultyLevel
 const compareDifficulty = compareNumeric((t) => t.difficultyLevel);
 const compareYearEstablishedUndefined = compareUndefinedLast((t) => t.yearEstablished);
 const compareYearEstablished = compareNumeric((t) => t.yearEstablished);
-const compareStickFrequencyUndefined = compareUndefinedLast((t) => t.stickFrequency);
-const compareStickFrequency = compareNumeric((t) => t.stickFrequency);
+
+// Stick frequency: an unset value matches the slider's "Never tried" default
+// (0) both visually on the card and in the long-press selector, so sorting
+// coalesces undefined to 0 instead of treating it as a separate bucket.
+function effectiveStickFrequency(t: Trick): number {
+  return t.stickFrequency ?? 0;
+}
 
 function compareLowerCaseString(a: string, b: string): number {
   if (a.toLowerCase() < b.toLowerCase()) return -1;
@@ -171,17 +176,11 @@ export function sortTricks(tricks: Trick[], sorting: SortOrder): Trick[] {
       );
     case 'stickFrequency-asc':
       return tricks.sort(
-        (a, b) =>
-          compareStickFrequencyUndefined(a, b) ||
-          compareStickFrequency(a, b) ||
-          comparePrimaryKey(a, b)
+        (a, b) => effectiveStickFrequency(a) - effectiveStickFrequency(b) || comparePrimaryKey(a, b)
       );
     case 'stickFrequency-desc':
       return tricks.sort(
-        (a, b) =>
-          compareStickFrequencyUndefined(a, b) ||
-          -compareStickFrequency(a, b) ||
-          comparePrimaryKey(a, b)
+        (a, b) => effectiveStickFrequency(b) - effectiveStickFrequency(a) || comparePrimaryKey(a, b)
       );
   }
 }

--- a/src/services/searchAndFilterTricks.ts
+++ b/src/services/searchAndFilterTricks.ts
@@ -118,6 +118,8 @@ const compareDifficultyUndefined = compareUndefinedLast((t) => t.difficultyLevel
 const compareDifficulty = compareNumeric((t) => t.difficultyLevel);
 const compareYearEstablishedUndefined = compareUndefinedLast((t) => t.yearEstablished);
 const compareYearEstablished = compareNumeric((t) => t.yearEstablished);
+const compareStickFrequencyUndefined = compareUndefinedLast((t) => t.stickFrequency);
+const compareStickFrequency = compareNumeric((t) => t.stickFrequency);
 
 function compareLowerCaseString(a: string, b: string): number {
   if (a.toLowerCase() < b.toLowerCase()) return -1;
@@ -165,6 +167,20 @@ export function sortTricks(tricks: Trick[], sorting: SortOrder): Trick[] {
         (a, b) =>
           compareYearEstablishedUndefined(a, b) ||
           -compareYearEstablished(a, b) ||
+          comparePrimaryKey(a, b)
+      );
+    case 'stickFrequency-asc':
+      return tricks.sort(
+        (a, b) =>
+          compareStickFrequencyUndefined(a, b) ||
+          compareStickFrequency(a, b) ||
+          comparePrimaryKey(a, b)
+      );
+    case 'stickFrequency-desc':
+      return tricks.sort(
+        (a, b) =>
+          compareStickFrequencyUndefined(a, b) ||
+          -compareStickFrequency(a, b) ||
           comparePrimaryKey(a, b)
       );
   }

--- a/src/services/tests/searchAndFilterTricks.test.ts
+++ b/src/services/tests/searchAndFilterTricks.test.ts
@@ -249,6 +249,43 @@ describe('sortTricks', () => {
     expect(ids).toEqual([3, 1, 2]);
   });
 
+  it('stickFrequency-asc: lower frequencies first, undefined at the end', () => {
+    const trickA = makeTrick({ id: 1, stickFrequency: 5 });
+    const trickB = makeTrick({ id: 2, stickFrequency: 1 });
+    const trickC = makeTrick({ id: 3, stickFrequency: 3 });
+    const trickD = makeTrick({ id: 4, stickFrequency: undefined });
+
+    const result = sortTricks([trickA, trickB, trickC, trickD], 'stickFrequency-asc');
+
+    const ids = result.map((t) => t.primaryKey[0]);
+    expect(ids).toEqual([2, 3, 1, 4]);
+  });
+
+  it('stickFrequency-desc: higher frequencies first, undefined at the end', () => {
+    const trickA = makeTrick({ id: 1, stickFrequency: 5 });
+    const trickB = makeTrick({ id: 2, stickFrequency: 1 });
+    const trickC = makeTrick({ id: 3, stickFrequency: 3 });
+    const trickD = makeTrick({ id: 4, stickFrequency: undefined });
+
+    const result = sortTricks([trickA, trickB, trickC, trickD], 'stickFrequency-desc');
+
+    const ids = result.map((t) => t.primaryKey[0]);
+    // 5, 3, 1 descending, undefined last.
+    expect(ids).toEqual([1, 3, 2, 4]);
+  });
+
+  it('stickFrequency-asc: treats 0 as a real value, not as undefined', () => {
+    const neverTried = makeTrick({ id: 1, stickFrequency: 0 });
+    const practicing = makeTrick({ id: 2, stickFrequency: 1 });
+    const noData = makeTrick({ id: 3, stickFrequency: undefined });
+
+    const result = sortTricks([noData, practicing, neverTried], 'stickFrequency-asc');
+
+    const ids = result.map((t) => t.primaryKey[0]);
+    // 0 comes before 1; undefined goes last.
+    expect(ids).toEqual([1, 2, 3]);
+  });
+
   it('difficulty-asc to startPos and back: should be sorted difficulty-asc', () => {
     const trickA = makeTrick({ id: 1, difficultyLevel: 1, startPosition: 'Exposure' });
     const trickB = makeTrick({ id: 2, difficultyLevel: 2, startPosition: 'Back' });

--- a/src/services/tests/searchAndFilterTricks.test.ts
+++ b/src/services/tests/searchAndFilterTricks.test.ts
@@ -249,7 +249,7 @@ describe('sortTricks', () => {
     expect(ids).toEqual([3, 1, 2]);
   });
 
-  it('stickFrequency-asc: lower frequencies first, undefined at the end', () => {
+  it('stickFrequency-asc: lower frequencies first; undefined sorts as 0', () => {
     const trickA = makeTrick({ id: 1, stickFrequency: 5 });
     const trickB = makeTrick({ id: 2, stickFrequency: 1 });
     const trickC = makeTrick({ id: 3, stickFrequency: 3 });
@@ -258,10 +258,12 @@ describe('sortTricks', () => {
     const result = sortTricks([trickA, trickB, trickC, trickD], 'stickFrequency-asc');
 
     const ids = result.map((t) => t.primaryKey[0]);
-    expect(ids).toEqual([2, 3, 1, 4]);
+    // Undefined coalesces to 0 (Never tried), so trick D sits before the
+    // explicit frequencies.
+    expect(ids).toEqual([4, 2, 3, 1]);
   });
 
-  it('stickFrequency-desc: higher frequencies first, undefined at the end', () => {
+  it('stickFrequency-desc: higher frequencies first; undefined sorts as 0', () => {
     const trickA = makeTrick({ id: 1, stickFrequency: 5 });
     const trickB = makeTrick({ id: 2, stickFrequency: 1 });
     const trickC = makeTrick({ id: 3, stickFrequency: 3 });
@@ -270,19 +272,19 @@ describe('sortTricks', () => {
     const result = sortTricks([trickA, trickB, trickC, trickD], 'stickFrequency-desc');
 
     const ids = result.map((t) => t.primaryKey[0]);
-    // 5, 3, 1 descending, undefined last.
+    // Undefined sorts as 0 and lands at the end.
     expect(ids).toEqual([1, 3, 2, 4]);
   });
 
-  it('stickFrequency-asc: treats 0 as a real value, not as undefined', () => {
-    const neverTried = makeTrick({ id: 1, stickFrequency: 0 });
-    const practicing = makeTrick({ id: 2, stickFrequency: 1 });
-    const noData = makeTrick({ id: 3, stickFrequency: undefined });
+  it('stickFrequency-asc: explicit 0 and undefined sort together (same bucket)', () => {
+    const neverTried = makeTrick({ id: 2, stickFrequency: 0 });
+    const noData = makeTrick({ id: 1, stickFrequency: undefined });
+    const practicing = makeTrick({ id: 3, stickFrequency: 1 });
 
-    const result = sortTricks([noData, practicing, neverTried], 'stickFrequency-asc');
+    const result = sortTricks([practicing, neverTried, noData], 'stickFrequency-asc');
 
     const ids = result.map((t) => t.primaryKey[0]);
-    // 0 comes before 1; undefined goes last.
+    // Both freq-0 tricks come first (tiebroken by primary key), then freq 1.
     expect(ids).toEqual([1, 2, 3]);
   });
 

--- a/src/types/search.ts
+++ b/src/types/search.ts
@@ -16,7 +16,7 @@ export type SearchItem = {
   isFavorite: boolean;
 };
 
-export type SortField = 'difficulty' | 'startPos' | 'endPos' | 'yearEstablished';
+export type SortField = 'difficulty' | 'startPos' | 'endPos' | 'yearEstablished' | 'stickFrequency';
 export type SortDirection = 'asc' | 'desc';
 
 export type SortOrder =
@@ -27,7 +27,9 @@ export type SortOrder =
   | 'endPos-asc'
   | 'endPos-desc'
   | 'yearEstablished-asc'
-  | 'yearEstablished-desc';
+  | 'yearEstablished-desc'
+  | 'stickFrequency-asc'
+  | 'stickFrequency-desc';
 
 export type TrickNameOption = 'alias' | 'technicalName';
 


### PR DESCRIPTION
## Summary

Three threads in one branch:

### 1. Sort UI redesign
- Replace the header "filter" popover with a dedicated **sort chip** below the search input: field dropdown (Difficulty / Start Position / End Position / Invention year / Stick frequency) + ↑/↓ direction toggle.
- Move the "Variations as tricks" preference into Settings next to the other trick-list options.
- Position fields gain a descending direction; legacy `startPos` / `endPos` localStorage entries migrate to `-asc` on load.

### 2. Trick-list performance pass
The list could mount ~1000 cards on initial load, and a sort field switch or clearing search forced Vue to re-mount the whole grid. Several layers tackled:

- **Cards live in a persistent Teleport pool.** Each Collapsible holds an empty target `<div>`; cards render in a hidden pool below and use `<Teleport :to defer>` to project themselves into the current section. Sort/search changes only flip the teleport destination, so card instances are reused rather than torn down.
- **Variations + count summary**: replaced O(visible × allTricks) re-scans with single-pass indices built per data change (not per sort).
- **`searchInTricks`** filters favorites before sorting (no more full-list double-sort) and caches the i18n group-attribute call.
- **Direction toggle DOM reuse**: Collapsibles key on section title alone; their `:key` no longer flips on `asc↔desc`, so Vue reorders cards instead of recreating them.
- **Per-card cost trimmed**:
  - Lazy reka-ui Popover (long-press + variations dropdown) — the heavy reka-ui subtree only mounts on first interaction.
  - Single shared `ResizeObserver` for card-text overflow detection instead of one per card.
  - Stable `EMPTY_VARIATIONS` constant prop reference.

### 3. Stick frequency as a new sort option
- New entry in the sort chip dropdown with both directions.
- Section headers reuse the existing level labels (Never tried, Practicing, …, Always).
- Treat an unset `stickFrequency` as `0`/Never tried to match what the card colour and the long-press slider already display for the same data.
- After a long-press commit, refresh the trick list cache when the popover closes so the card slides to its new section without shifting the canvas under the user's finger mid-gesture (`trickListRefreshKey` provide/inject; `TrickStickFrequencySelector` now emits `commit`).

### Bonus fix
- Collapsibles no longer replay their expand animation on navigation back from a child route — pin inline `animation-name: none` after each user-triggered animation completes, so the KeepAlive detach+reattach can't restart the CSS animation rule.

## Test plan

- [ ] Initial trick list load shows sections + cards correctly.
- [ ] Sort direction toggle (↑↔↓) is fast and animation-free for collapsed sections.
- [ ] Sort field switch (Difficulty → Start Position → Year → Stick Frequency …) is fast; no jank.
- [ ] Search: type a query, results ordered by relevance; clear via X returns to the full list quickly.
- [ ] Collapse a section, navigate to trick details, navigate back — the section does **not** re-animate open.
- [ ] Collapse "Difficulty 1" on `difficulty-asc`, toggle to `difficulty-desc` — the section stays collapsed (no flash-open-then-close).
- [ ] Long-press a card → frequency slider opens. Drag + release. Tap backdrop. While sorting by stick frequency, the card slides into its new section as the popover closes.
- [ ] Tricks the user has never touched group under "Never tried" when sorted by stick frequency, not "Unknown".
- [ ] Variations dropdown still opens, navigates to a variation, and returns correctly.
- [ ] Favorites section: a favorite trick still appears in both the Favorites section and its sort group.
- [ ] All four locales (EN/ES/FR/PT) show translated labels for the new sort option and stick-frequency section titles.

https://claude.ai/code/session_01RJKRFPmcmZikCG1bMPuqnS

---
_Generated by [Claude Code](https://claude.ai/code/session_01RJKRFPmcmZikCG1bMPuqnS)_