### PR TITLE
refactor(trickForm): collapse videos section behind add button

### DIFF
--- a/src/components/stickable/trick/TrickForm.vue
+++ b/src/components/stickable/trick/TrickForm.vue
@@ -7,11 +7,7 @@ import { toTypedSchema } from '@vee-validate/zod';
 import messages from '@/i18n/tricks/new/index';
 import messagesPositions from '@/i18n/common/positions';
 import { i18nMerge } from '@/i18n/i18nmerge';
-import {
-  DbPositionZod,
-  DbReferenceZod,
-  DbVideoZod,
-} from '@/lib/database/schemas/CurrentVersionSchema';
+import { DbPositionZod, DbReferenceZod } from '@/lib/database/schemas/CurrentVersionSchema';
 
 import { Button } from '@/components/ui/button';
 import PositionSelectInput from '@/components/ui/customForm/PositionSelectInput.vue';
@@ -62,7 +58,18 @@ const trickFormSchema = z.object({
   ]),
   variationOf: z.array(DbReferenceZod).optional(),
   recommendedPrerequisites: z.array(DbReferenceZod).optional(),
-  videos: z.array(DbVideoZod).optional(),
+  videos: z
+    .array(
+      z.object({
+        link: z
+          .string()
+          .min(1, { message: 'INPUT_REQUIRED_URL' })
+          .url({ message: 'INPUT_INVALID_URL' }),
+        startTime: z.number().min(0).optional(),
+        endTime: z.number().min(0).optional(),
+      })
+    )
+    .optional(),
 });
 
 export type TrickFormSchema = z.infer<typeof trickFormSchema>;

--- a/src/components/ui/customForm/MultiVideoSelect.vue
+++ b/src/components/ui/customForm/MultiVideoSelect.vue
@@ -173,8 +173,9 @@ function normalizeLink(video: DbVideo) {
 
           <Button
             variant="outline"
+            size="sm"
             type="button"
-            class="self-start font-normal"
+            class="self-start w-fit font-normal"
             @click="
               () => {
                 if (!componentField.modelValue) componentField.modelValue = [];
@@ -182,7 +183,7 @@ function normalizeLink(video: DbVideo) {
               }
             "
           >
-            <Icon icon="ic:round-add" class="w-5 h-5 mr-1" />
+            <Icon icon="ic:round-add" class="w-4 h-4 mr-1" />
             {{ t('buttons.addVideo') }}
           </Button>
         </div>

--- a/src/components/ui/customForm/MultiVideoSelect.vue
+++ b/src/components/ui/customForm/MultiVideoSelect.vue
@@ -41,6 +41,16 @@ function initialEndTime(video: DbVideo): number {
   const MAX_TIME_VALUE = 24 * 60 * 60 - 1;
   return Math.min(video.startTime + 1, MAX_TIME_VALUE);
 }
+
+function normalizeLink(video: DbVideo) {
+  const trimmed = video.link.trim();
+  if (trimmed === '') return;
+  if (!/^https?:\/\//i.test(trimmed)) {
+    video.link = 'https://' + trimmed;
+  } else if (trimmed !== video.link) {
+    video.link = trimmed;
+  }
+}
 </script>
 
 <template>
@@ -82,9 +92,10 @@ function initialEndTime(video: DbVideo): number {
                 }}</FormLabel>
                 <Input
                   type="text"
-                  placeholder="www.youtube.com/..."
+                  placeholder="https://www.youtube.com/..."
                   :modelValue="video.link"
                   @update:model-value="(val) => (video.link = val.toString())"
+                  @blur="() => normalizeLink(video)"
                 />
               </div>
 

--- a/src/components/ui/customForm/MultiVideoSelect.vue
+++ b/src/components/ui/customForm/MultiVideoSelect.vue
@@ -1,6 +1,4 @@
 <script lang="ts" setup>
-import { ref } from 'vue';
-
 import { cn } from '@/lib/utils';
 import { Icon } from '@iconify/vue/dist/iconify.js';
 import {
@@ -33,60 +31,15 @@ const props = defineProps<{
 
 type DbVideo = z.infer<typeof DbVideoZod>;
 
-const link = ref<DbVideo['link']>('');
-const startTime = ref<DbVideo['startTime']>(undefined);
-const endTime = ref<DbVideo['endTime']>(undefined);
-
-function initialStartingTime(): DbVideo['startTime'] {
-  if (endTime.value === undefined) {
-    return 0;
-  }
-
-  return Math.max(0, endTime.value - 1);
+function initialStartTime(video: DbVideo): number {
+  if (video.endTime === undefined) return 0;
+  return Math.max(0, video.endTime - 1);
 }
 
-function initialEndTime(): DbVideo['endTime'] {
-  if (startTime.value === undefined) {
-    return 0;
-  }
-
+function initialEndTime(video: DbVideo): number {
+  if (video.startTime === undefined) return 0;
   const MAX_TIME_VALUE = 24 * 60 * 60 - 1;
-  return Math.min(startTime.value + 1, MAX_TIME_VALUE);
-}
-
-function newVideoObjectFromFields(): DbVideo {
-  return {
-    link: link.value,
-    startTime: startTime.value,
-    endTime: endTime.value,
-  };
-}
-
-function resetAddFields() {
-  link.value = '';
-  startTime.value = undefined;
-  endTime.value = undefined;
-}
-
-/**
- * Takes a number of seconds and pretty prints in hh:mm:ss notation
- * e.g. 54 -> 00:00:54
- *      125 -> 00:02:05
- */
-function hoursMinutesSecondsFromSeconds(seconds: number): string {
-  let hours: number = Math.floor(seconds / 60 / 60);
-  seconds -= hours * 60 * 60;
-
-  let minutes: number = Math.floor(seconds / 60);
-  seconds -= minutes * 60;
-
-  return (
-    zeroPadNumber(hours, 2) + ':' + zeroPadNumber(minutes, 2) + ':' + zeroPadNumber(seconds, 2)
-  );
-}
-
-function zeroPadNumber(number_: number, minLength: number): string {
-  return number_.toString().padStart(minLength, '0');
+  return Math.min(video.startTime + 1, MAX_TIME_VALUE);
 }
 </script>
 
@@ -106,136 +59,121 @@ function zeroPadNumber(number_: number, minLength: number): string {
       <FormMessage />
 
       <FormControl>
-        <div
-          v-if="componentField && componentField.modelValue && componentField.modelValue.length > 0"
-          class="flex flex-col divide divide-y divide-border rounded-sm border border-border p-0"
-        >
+        <div class="flex flex-col gap-2">
           <div
-            v-for="(video, index) in componentField.modelValue"
-            :key="video.url"
-            class="p-3 flex flex-row items-center justify-between"
+            v-for="(video, index) in componentField.modelValue ?? []"
+            :key="index"
+            class="flex flex-col gap-1 border border-border rounded-sm p-2 relative"
           >
-            <div class="flex flex-col gap-2">
-              <a :href="video.link" class="underline text-sm">{{ video.link }}</a>
-              <div
-                v-if="video.startTime !== undefined || video.endTime !== undefined"
-                class="flex flex-row gap-5 w-64 text-sm text-muted-foreground"
-              >
-                <div v-if="video.startTime !== undefined" class="flex flex-row gap-1">
-                  <Icon icon="ic:round-play-arrow" class="w-5 h-5" />
-                  {{ hoursMinutesSecondsFromSeconds(video.startTime) }}
-                </div>
-                <div v-if="video.endTime !== undefined" class="flex flex-row gap-1">
-                  <Icon icon="ic:round-stop" class="w-5 h-5" />
-                  {{ hoursMinutesSecondsFromSeconds(video.endTime) }}
-                </div>
-              </div>
-            </div>
             <Button
               variant="ghost"
               size="icon"
-              class="p-0 rounded-full"
+              type="button"
+              class="absolute top-1 right-1 p-0 rounded-full"
               @click="() => componentField.modelValue.splice(index, 1)"
             >
               <Icon icon="ic:round-close" class="w-5 h-5" />
             </Button>
-          </div>
-        </div>
 
-        <div class="flex flex-col gap-1 border border-border rounded-sm p-1">
-          <div class="flex flex-col lg:flex-row gap-1">
-            <div class="grow-1 w-full">
-              <FormLabel class="font-normal text-muted-foreground">{{ t('labels.url') }}</FormLabel>
-              <Input
-                type="text"
-                placeholder="www.youtube.com/..."
-                :modelValue="link"
-                @update:model-value="(val) => (link = val.toString())"
-              />
-            </div>
-
-            <div class="flex flex-row gap-2 flex-wrap w-fit shrink-0 grow-0">
-              <div>
+            <div class="flex flex-col lg:flex-row gap-1 pr-8">
+              <div class="grow-1 w-full">
                 <FormLabel class="font-normal text-muted-foreground">{{
-                  t('labels.start')
+                  t('labels.url')
                 }}</FormLabel>
-                <div class="flex flex-row">
-                  <TimePicker
-                    v-if="startTime !== undefined"
-                    v-model:time="startTime"
-                    @update:time="(value) => (startTime = value)"
-                    with-seconds
-                  />
-                  <Button
-                    v-if="startTime !== undefined"
-                    variant="ghost"
-                    size="icon"
-                    class="px-1"
-                    @click="() => (startTime = undefined)"
-                  >
-                    <Icon icon="ic:round-close" class="w-5 h-5" />
-                  </Button>
-                  <Button
-                    v-else
-                    variant="outline"
-                    class="font-normal px-3"
-                    @click="() => (startTime = initialStartingTime())"
-                  >
-                    <Icon icon="ic:round-add" class="w-6 h-6 mr-1" />
-                    <span class="text-muted-foreground">({{ t('buttons.optional') }})</span>
-                  </Button>
-                </div>
+                <Input
+                  type="text"
+                  placeholder="www.youtube.com/..."
+                  :modelValue="video.link"
+                  @update:model-value="(val) => (video.link = val.toString())"
+                />
               </div>
 
-              <div>
-                <FormLabel class="font-normal text-muted-foreground">{{
-                  t('labels.end')
-                }}</FormLabel>
-                <div class="flex flex-row">
-                  <TimePicker
-                    v-if="endTime !== undefined"
-                    v-model:time="endTime"
-                    @update:time="(value) => (endTime = value)"
-                    with-seconds
-                  />
-                  <Button
-                    v-if="endTime !== undefined"
-                    variant="ghost"
-                    size="icon"
-                    class="px-1"
-                    @click="() => (endTime = undefined)"
-                  >
-                    <Icon icon="ic:round-close" class="w-5 h-5" />
-                  </Button>
-                  <Button
-                    v-else
-                    variant="outline"
-                    class="font-normal px-3"
-                    @click="() => (endTime = initialEndTime())"
-                  >
-                    <Icon icon="ic:round-add" class="w-6 h-6 mr-1" />
-                    <span class="text-muted-foreground">({{ t('buttons.optional') }})</span>
-                  </Button>
+              <div class="flex flex-row gap-2 flex-wrap w-fit shrink-0 grow-0">
+                <div>
+                  <FormLabel class="font-normal text-muted-foreground">{{
+                    t('labels.start')
+                  }}</FormLabel>
+                  <div class="flex flex-row">
+                    <TimePicker
+                      v-if="video.startTime !== undefined"
+                      :time="video.startTime"
+                      @update:time="(value) => (video.startTime = value)"
+                      with-seconds
+                    />
+                    <Button
+                      v-if="video.startTime !== undefined"
+                      variant="ghost"
+                      size="icon"
+                      type="button"
+                      class="px-1"
+                      @click="() => (video.startTime = undefined)"
+                    >
+                      <Icon icon="ic:round-close" class="w-5 h-5" />
+                    </Button>
+                    <Button
+                      v-else
+                      variant="outline"
+                      type="button"
+                      class="font-normal px-3"
+                      @click="() => (video.startTime = initialStartTime(video))"
+                    >
+                      <Icon icon="ic:round-add" class="w-6 h-6 mr-1" />
+                      <span class="text-muted-foreground">({{ t('buttons.optional') }})</span>
+                    </Button>
+                  </div>
+                </div>
+
+                <div>
+                  <FormLabel class="font-normal text-muted-foreground">{{
+                    t('labels.end')
+                  }}</FormLabel>
+                  <div class="flex flex-row">
+                    <TimePicker
+                      v-if="video.endTime !== undefined"
+                      :time="video.endTime"
+                      @update:time="(value) => (video.endTime = value)"
+                      with-seconds
+                    />
+                    <Button
+                      v-if="video.endTime !== undefined"
+                      variant="ghost"
+                      size="icon"
+                      type="button"
+                      class="px-1"
+                      @click="() => (video.endTime = undefined)"
+                    >
+                      <Icon icon="ic:round-close" class="w-5 h-5" />
+                    </Button>
+                    <Button
+                      v-else
+                      variant="outline"
+                      type="button"
+                      class="font-normal px-3"
+                      @click="() => (video.endTime = initialEndTime(video))"
+                    >
+                      <Icon icon="ic:round-add" class="w-6 h-6 mr-1" />
+                      <span class="text-muted-foreground">({{ t('buttons.optional') }})</span>
+                    </Button>
+                  </div>
                 </div>
               </div>
             </div>
           </div>
 
-          <div class="flex flex-row justify-end">
-            <Button
-              variant="default"
-              :disabled="link === undefined || link === ''"
-              @click="
-                () => {
-                  const newVideo = newVideoObjectFromFields();
-                  componentField.modelValue.push(newVideo);
-                  resetAddFields();
-                }
-              "
-            >
-              {{ t('buttons.add') }}
-            </Button>
-          </div>
+          <Button
+            variant="outline"
+            type="button"
+            class="self-start font-normal"
+            @click="
+              () => {
+                if (!componentField.modelValue) componentField.modelValue = [];
+                componentField.modelValue.push({ link: '' });
+              }
+            "
+          >
+            <Icon icon="ic:round-add" class="w-5 h-5 mr-1" />
+            {{ t('buttons.addVideo') }}
+          </Button>
         </div>
       </FormControl>
     </FormItem>

--- a/src/i18n/error/error.en.json
+++ b/src/i18n/error/error.en.json
@@ -10,5 +10,7 @@
   "INPUT_NUMBER_ABOVE_MAX": "Input must be no more than {max}",
   "POSITION_INVALID": "Provided Position is invalid",
   "INPUT_TOO_SHORT": "Input must be at least {limit} characters long",
-  "INPUT_TOO_LONG": "Input must be at most {limit} characters long"
+  "INPUT_TOO_LONG": "Input must be at most {limit} characters long",
+  "INPUT_REQUIRED_URL": "Please enter a URL",
+  "INPUT_INVALID_URL": "Please enter a valid URL"
 }

--- a/src/i18n/error/error.es.json
+++ b/src/i18n/error/error.es.json
@@ -10,5 +10,7 @@
   "INPUT_NUMBER_ABOVE_MAX": "La entrada no debe ser mayor que {max}",
   "POSITION_INVALID": "Proporcionado La posición no es válida",
   "INPUT_TOO_SHORT": "La entrada debe tener al menos {limit} caracteres",
-  "INPUT_TOO_LONG": "La entrada debe tener como máximo {limit} caracteres"
+  "INPUT_TOO_LONG": "La entrada debe tener como máximo {limit} caracteres",
+  "INPUT_REQUIRED_URL": "Introduzca una URL",
+  "INPUT_INVALID_URL": "Introduzca una URL válida"
 }

--- a/src/i18n/error/error.fr.json
+++ b/src/i18n/error/error.fr.json
@@ -10,5 +10,7 @@
   "INPUT_NUMBER_ABOVE_MAX": "L'entrée ne doit pas dépasser {max}",
   "POSITION_INVALID": "Fourni La position n'est pas valide",
   "INPUT_TOO_SHORT": "L'entrée doit comporter au moins {limit} caractères",
-  "INPUT_TOO_LONG": "L'entrée doit comporter au maximum {limit} caractères"
+  "INPUT_TOO_LONG": "L'entrée doit comporter au maximum {limit} caractères",
+  "INPUT_REQUIRED_URL": "Veuillez saisir une URL",
+  "INPUT_INVALID_URL": "Veuillez saisir une URL valide"
 }

--- a/src/i18n/error/error.pt.json
+++ b/src/i18n/error/error.pt.json
@@ -10,5 +10,7 @@
   "INPUT_NUMBER_ABOVE_MAX": "O valor não deve ser maior que {max}",
   "POSITION_INVALID": "A Posição fornecida é inválida",
   "INPUT_TOO_SHORT": "A entrada deve ter pelo menos {limit} caracteres",
-  "INPUT_TOO_LONG": "A entrada deve ter no máximo {limit} caracteres"
+  "INPUT_TOO_LONG": "A entrada deve ter no máximo {limit} caracteres",
+  "INPUT_REQUIRED_URL": "Por favor, insira uma URL",
+  "INPUT_INVALID_URL": "Por favor, insira uma URL válida"
 }

--- a/src/i18n/ui/multiVideoSelect/multiVideoSelect.en.json
+++ b/src/i18n/ui/multiVideoSelect/multiVideoSelect.en.json
@@ -6,6 +6,7 @@
   },
   "buttons": {
     "optional": "optional",
-    "add": "Add"
+    "add": "Add",
+    "addVideo": "Add video"
   }
 }

--- a/src/i18n/ui/multiVideoSelect/multiVideoSelect.es.json
+++ b/src/i18n/ui/multiVideoSelect/multiVideoSelect.es.json
@@ -6,6 +6,7 @@
   },
   "buttons": {
     "optional": "opcional",
-    "add": "Añadir"
+    "add": "Añadir",
+    "addVideo": "Añadir vídeo"
   }
 }

--- a/src/i18n/ui/multiVideoSelect/multiVideoSelect.fr.json
+++ b/src/i18n/ui/multiVideoSelect/multiVideoSelect.fr.json
@@ -6,6 +6,7 @@
   },
   "buttons": {
     "optional": "optionnel",
-    "add": "Ajouter"
+    "add": "Ajouter",
+    "addVideo": "Ajouter une vidéo"
   }
 }

--- a/src/i18n/ui/multiVideoSelect/multiVideoSelect.pt.json
+++ b/src/i18n/ui/multiVideoSelect/multiVideoSelect.pt.json
@@ -6,6 +6,7 @@
   },
   "buttons": {
     "optional": "opcional",
-    "add": "Adicionar"
+    "add": "Adicionar",
+    "addVideo": "Adicionar vídeo"
   }
 }


### PR DESCRIPTION
Videos field now renders an empty state with a single outline "Add video"
button. Each click appends a new editable card (URL + optional start/end
times + remove). Removes the always-visible draft form so the primary
submit button is no longer competing with a blue "Add" button